### PR TITLE
fix(FastBitCopyModule): skip hook when BitCopyFast.cpp took the fallback path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ CI/build-*/
 # ---- OS junk ----
 .DS_Store
 Thumbs.db
+  
+# Agent scratch directory (local only, never committed)  
+.agent/  

--- a/Source/FastBitCopy/Private/FastBitCopyModule.cpp
+++ b/Source/FastBitCopy/Private/FastBitCopyModule.cpp
@@ -15,6 +15,15 @@ DEFINE_LOG_CATEGORY_STATIC(LogFastBitCopy, Log, All);
 // with CORE_API here guarantees we link to the same exported symbol.
 CORE_API void appBitsCpy(uint8* Dest, int32 DestBit, uint8* Src, int32 SrcBit, int32 BitCount);
 
+// Build-path self-identification probe, defined in BitCopyFast.cpp. Returns 1
+// iff that translation unit compiled the real optimized path, 0 if it
+// compiled the fallback-to-stock path. The latter happens on any compiler
+// where we have not yet validated the optimized code (currently: everything
+// except MSVC, see issue #2). Installing the hook in the fallback case would
+// create an infinite recursion (HookedAppBitsCpy -> appBitsCpyFastImpl ->
+// appBitsCpy -> HookedAppBitsCpy -> ...), so we must gate off of it.
+CORE_API int FastBitCopy_IsOptimizedBuild();
+
 namespace
 {
 	static FFunctionHook GBitsCpyHook;
@@ -30,6 +39,17 @@ namespace
 void FFastBitCopyModule::StartupModule()
 {
 #if PLATFORM_LITTLE_ENDIAN && PLATFORM_SUPPORTS_UNALIGNED_LOADS
+	if (FastBitCopy_IsOptimizedBuild() == 0)
+	{
+		// BitCopyFast.cpp compiled the fallback path (appBitsCpyFastImpl
+		// is just a thunk to appBitsCpy). Installing the hook here would
+		// turn that thunk into an infinite self-call. Skip.
+		UE_LOG(LogFastBitCopy, Log,
+			   TEXT("FastBitCopy: compiled in fallback mode on this toolchain; skipping hook. ")
+				   TEXT("(see issue #2 for the MSVC-vs-GCC/Clang investigation)"));
+		return;
+	}
+
 	void* Target = (void*)&appBitsCpy;
 	void* Detour = (void*)&HookedAppBitsCpy;
 


### PR DESCRIPTION
## What

Fix a latent infinite-recursion bug in `FastBitCopyModule::StartupModule()`: when `BitCopyFast.cpp` compiled the fallback branch on a non-MSVC toolchain, installing the hook would create `appBitsCpy -> HookedAppBitsCpy -> appBitsCpyFastImpl -> appBitsCpy -> ...` — stack overflow at the first `BitReader` call.

Also ignore `.agent/` so local agent scratch files can never land in commits.

## Why

The comment in `BitCopyFast.cpp` has been claiming "StartupModule() skips the hook when `FastBitCopy_IsOptimizedBuild()` returns 0" for a while now, but the module never actually read the probe — its gate was only `PLATFORM_LITTLE_ENDIAN && PLATFORM_SUPPORTS_UNALIGNED_LOADS`. That gate is insufficient on any toolchain where `BitCopyFast.cpp` selected the fallback branch (where `appBitsCpyFastImpl` is a thunk to stock `appBitsCpy`).

The crash has not been observed in practice because:
- all correctness testing happens on MSVC (probe=1, optimized path compiled, no fallback), or
- the standalone `CI/` harness doesn't load the UE module at all and therefore never runs `StartupModule()`.

But it would trigger the first time a non-MSVC consumer enabled this plugin in a real editor/game build.

## What changed

- **`Source/FastBitCopy/Private/FastBitCopyModule.cpp`**:
  - Forward-declare `CORE_API int FastBitCopy_IsOptimizedBuild()` (defined in `BitCopyFast.cpp`, returns 1 on the optimized build, 0 on the fallback build).
  - `StartupModule()` now checks it first and early-returns with a log line when the probe returns 0, before touching the hook installer.
- **`.gitignore`**: add `.agent/` for agent scratch files.

## What did NOT change

- **`BitCopyFast.cpp`** is not touched in this PR. Cleaning up the dead `optimize("O0")` / `optnone` attributes and collapsing the gate into a `FASTBITCOPY_HAVE_OPTIMIZED_PATH` macro is a follow-up PR, because doing it properly requires a matching change to the standalone `CI/` harness (the harness compiles `BitCopyFast.cpp` directly but cannot link against UE's stock `appBitsCpy`, so the fallback branch breaks standalone linking on GCC/Clang).
- The CI matrix is unchanged.
- The public API is unchanged.
- MSVC behavior is byte-for-byte identical.

## Verification

Windows MSVC (`Visual Studio 17 2022`, `x64`, `Release`), standalone `CI/` harness:

```
[info] FastBitCopy_IsOptimizedBuild = 1
[ OK ] edge cases: 11 passed
[ OK ] correctness: 20000 random trials passed
[bench] aligned   Original 496.9 ns/op   Fast 12.6 ns/op   (~39x)
[bench] unaligned Original 487.4 ns/op   Fast 138.0 ns/op  (~3.5x)
```

The probe-check change itself is **validated only by inspection**. Neither the standalone harness nor the CI matrix exercises a non-MSVC UE module load, so there is no automated coverage of the early-return path. A proper integration test is blocked on resolving #2 (GCC/Clang `-O2` miscompile).

## Note on force-push

The original push of this branch included a second commit that also touched `BitCopyFast.cpp` and ended up breaking the standalone harness on Linux/macOS (undefined reference to `appBitsCpy` — the fallback branch cannot link without UE). That commit has been amended out to narrow scope to the module-only bug fix, which does not have that problem. CI should now be green on this PR on every platform.
