### PR TITLE
fix(CI/ue_shim): FMath::Min/Max returned dangling reference (root cause of Linux/macOS -O2 failures)

### DIFF
--- a/CI/ue_shim.h
+++ b/CI/ue_shim.h
@@ -48,13 +48,21 @@ using int64  = std::int64_t;
 
 struct FMath
 {
-    template <class A, class B>
-    static constexpr auto Min(A a, B b) -> decltype(a < b ? a : b)
+    // NOTE: return by value, NOT by the deduced type of a conditional
+    // expression.  `decltype(a < b ? a : b)` on two same-typed lvalues
+    // yields an lvalue reference, which would make Min/Max return a
+    // dangling reference to a by-value parameter -- observed as an
+    // AddressSanitizer "stack-use-after-return" at -O2 on GCC/Clang
+    // (the -O0 CI jobs happened to not reuse the stack slot so the
+    // bug was masked there).  Keep the signature close to UE's real
+    // FMath::Min<T>(T,T) which also returns by value.
+    template <class T>
+    static constexpr T Min(T a, T b)
     {
         return a < b ? a : b;
     }
-    template <class A, class B>
-    static constexpr auto Max(A a, B b) -> decltype(a > b ? a : b)
+    template <class T>
+    static constexpr T Max(T a, T b)
     {
         return a > b ? a : b;
     }


### PR DESCRIPTION
## Summary

The `Sanitizers (ubuntu-latest)` job finally told us the real story: the
non-MSVC CI failure is **not** a GCC/Clang miscompile of `BitCopyFast.cpp`.
It is a dangling-reference bug in our own CI shim, `CI/ue_shim.h`, that
happened to be invisible at `-O0` and loud at `-O2`.

AddressSanitizer report (from the last failing run on `main`):

```
==2344==ERROR: AddressSanitizer: stack-use-after-return on address 0x7fceec600030
    #0 BitsCopyFastUnaligned  Source/FastBitCopy/Private/BitCopyFast.cpp:183
    #1 appBitsCpyFastImpl     Source/FastBitCopy/Private/BitCopyFast.cpp:352
    #2 main                   CI/test_main.cpp:249

Address 0x7fceec600030 is located in stack of thread T0 at offset 48 in frame
    #0 FMath::Min<int,int>(int, int)   CI/ue_shim.h:52
  This frame has 2 object(s):
    [48, 52) 'a' (line 52) <== Memory access at offset 48 is inside this variable
```

The memory being read by `BitsCopyFastUnaligned` at line 183 belongs to
`FMath::Min`'s own stack frame, specifically parameter `a`. That only
makes sense if `Min` was returning a reference to `a`, not a copy.

## Root cause

```cpp
template <class A, class B>
static constexpr auto Min(A a, B b) -> decltype(a < b ? a : b)
{
    return a < b ? a : b;
}
```

`decltype(a < b ? a : b)` where `a` and `b` are same-typed **lvalues**
evaluates to an **lvalue reference type** (`int&`). So the trailing
return type is `int&`, and `Min` returns a reference to its
by-value parameter -- a dangling reference the moment `Min` returns.

Why it stayed hidden:

* **`-O2`**: the caller (`BitsCopyFastUnaligned`) has `const int CopyBits
  = FMath::Min(CopySrcBits, BitCount);`. The compiler materialises
  `CopyBits` by reading from the returned reference slot *after* `Min`
  has returned, by which time the stack has been reused. That is the
  UB. ASan's `detect_stack_use_after_return=1` (default on this
  toolchain) is what made it a deterministic error.
* **`-O0`**: no stack reuse, the dead slot still had the correct value,
  so the job kept passing. That is why every `Standalone test -O0` run
  was green and we kept (wrongly) concluding that the helpers
  themselves needed to be pinned to `-O0`.
* **MSVC**: different codegen for same-type `?:` + different stack
  layout meant the read happened to still be valid.

Essentially every "fix" we tried on `BitCopyFast.cpp` itself --
`optnone`, `noinline`, `asm ("" ::: "memory")` barriers, forcing
`uint32` intermediates for the shifts -- was treating a symptom of a
bug that lives two files away.

## Fix

Return by value, matching UE's real `FMath::Min<T>(T, T)`:

```cpp
template <class T>
static constexpr T Min(T a, T b) { return a < b ? a : b; }
template <class T>
static constexpr T Max(T a, T b) { return a > b ? a : b; }
```

`BitCopyFast.cpp` only ever calls `FMath::Min(int, int)` /
`FMath::Max(int, int)`, so collapsing the two template parameters into
one `T` is safe. The shim is only used by the standalone CI harness;
the in-engine plugin build links against real UE `FMath` and was
never affected.

## Verification (actual CI on this branch)

| Job | Before (`main`) | After (this PR) |
| --- | --- | --- |
| Standalone test **(ubuntu-latest, -O2)** | :x: | :white_check_mark: |
| Standalone test **(macos-latest, -O2)**  | :x: | :white_check_mark: |
| Standalone test (windows-latest, MSVC)   | :white_check_mark: | :white_check_mark: |
| Standalone test -O0 (ubuntu / macos)     | :white_check_mark: | :white_check_mark: |
| arm64 cross-build (linux)                | :white_check_mark: | :white_check_mark: |
| Dump -O2 assembly (linux)                | :white_check_mark: | :white_check_mark: |
| Validate .uplugin                        | :white_check_mark: | :white_check_mark: |
| **Sanitizers (ubuntu-latest)**           | :x: (SUAR)        | :x: (*different* bug -- see below) |

The `-O2` functional failures on Linux and macOS -- the entire
motivation for this PR -- are **fixed**.

## What remains red and why I am *not* fixing it in this PR

The `Sanitizers` job is still red, but with a completely different
error that only became reachable once we stopped crashing on the
stack-use-after-return:

```
BitCopyFast.cpp:133:20: runtime error: load of misaligned address
0x521000000101 for type 'long unsigned int', which requires 8 byte alignment
```

Line 133 is `const WordType Word = Src[i];`, i.e. dereferencing a
`uint64*` that was cast from `uint8*` at an arbitrary byte offset.
On x86/x64 the hardware is happy to do this (that is exactly what
`PLATFORM_SUPPORTS_UNALIGNED_LOADS=1` promises), so the code is
*functionally* correct -- which is why every non-sanitized job is
now green. But it is language-level UB according to C++, and UBSan
with `-fsanitize=alignment` (on by default in the Sanitizers job) is
specifically there to catch exactly this.

This is a pre-existing issue, not regressed by this PR. It was
simply masked before: the earlier stack-use-after-return aborted the
sanitized run inside `BitsCopyFastUnaligned` long before execution
ever reached this aligned-path load. Now that the crash is gone,
UBSan runs further and surfaces the next latent issue.

I am keeping it out of this PR deliberately, because:

1. It is a different class of bug (language-level alignment UB vs
   lifetime UB).
2. The fix touches production code (`BitCopyFast.cpp`), not the
   test shim, so the reviewer's attention should be separate.
3. This PR's claim -- "fix the `-O2` Linux/macOS failures" -- is
   already fully substantiated by the table above, and inflating
   scope would muddy the bisect story.

## Follow-ups (tracked separately, not in this PR)

1. `BitCopyFast.cpp`: replace raw `uint64*` dereferences with
   `std::memcpy`-based reads/writes so the code is both
   language-legal and optimal (Clang/GCC collapse `memcpy(&w,p,8)`
   to a single load). Closes the Sanitizers alignment warning.
2. `BitCopyFast.cpp`: revert the defensive noise accumulated while
   we were chasing the wrong bug -- `optimize("O0")` /
   `__attribute__((optnone))` / `asm ("" ::: "memory")` barriers /
   manual `uint32` promotions for the shift chain. None of it was
   needed; it was all treating symptoms of the shim bug.
3. `FastBitCopyModule.cpp`: re-enable the hook on non-MSVC builds
   (we disabled it defensively while fallback was believed
   necessary; now that the helpers are provably correct, the hook
   can go back on).
4. `README.md`: drop the "Linux / macOS: partial" language and
   close #2.
5. `agent-skills`: record the lesson
   (`decltype(cond ? a : b)` on same-typed lvalues yields
   `T&`; never use it as a trailing return type for a function
   that took its operands by value).
