### PR TITLE
fix(BitCopyFast): resolve UBSan alignment UB in CopyBitsSrcAligned

### DIFF
--- a/Source/FastBitCopy/Private/BitCopyFast.cpp
+++ b/Source/FastBitCopy/Private/BitCopyFast.cpp
@@ -8,6 +8,7 @@
 #include "CoreMinimal.h"
 #include "Math/UnrealMathUtility.h"
 #include <atomic>
+#include <cstring>
 
 // A *real* compiler barrier. std::atomic_signal_fence turned out to be
 // insufficient on Clang/GCC -O2 (it disciplines reorderings with respect to
@@ -94,6 +95,35 @@ static FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void BitsCopyFastAligned(uint8 
 	}
 }
 
+// Unaligned word load/store. Clang/GCC/MSVC all fold sizeof-bounded
+// memcpy of a trivially-copyable scalar to a single machine load/store
+// at -O1 and above, so this is both language-legal (no strict-aliasing
+// or alignment UB) *and* generates the same single `mov` we want on
+// x86/x64 and arm64. On platforms with hardware-misaligned-load support
+// (PLATFORM_SUPPORTS_UNALIGNED_LOADS) the runtime cost is identical to
+// a raw `*p` dereference; the difference is strictly in what the C++
+// standard and UBSan consider well-defined.
+//
+// Rationale for not just reverting to `Dest[i] = Src[i]`: `CopyBitsSrcAligned`
+// is called from `BitsCopyFastUnaligned` after a leading-byte alignment pass
+// that only guarantees *byte* alignment of the remaining pointer, then casts
+// it to `uint64*`. UBSan with `-fsanitize=alignment` correctly flags that
+// cast-then-dereference sequence as UB; wrapping the access in memcpy is the
+// standard, zero-cost resolution.
+template <typename WordType>
+static FORCEINLINE WordType LoadWordUnaligned(const WordType *P)
+{
+	WordType W;
+	std::memcpy(&W, P, sizeof(W));
+	return W;
+}
+
+template <typename WordType>
+static FORCEINLINE void StoreWordUnaligned(WordType *P, WordType W)
+{
+	std::memcpy(P, &W, sizeof(W));
+}
+
 // Copy bits with source bit offset aligned.
 template <typename WordType>
 static FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void CopyBitsSrcAligned(WordType *Dest, int DestBit, WordType *Src, int BitCount)
@@ -121,7 +151,7 @@ static FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void CopyBitsSrcAligned(WordTyp
 		{
 			for (int i = 0; i < LoopCount; ++i)
 			{
-				Dest[i] = Src[i];
+				StoreWordUnaligned(&Dest[i], LoadWordUnaligned(&Src[i]));
 			}
 		}
 		else
@@ -130,9 +160,11 @@ static FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void CopyBitsSrcAligned(WordTyp
 			const uint32 UDestCopyBits = uint32(DestCopyBits);
 			for (int i = 0; i < LoopCount; ++i)
 			{
-				const WordType Word = Src[i];
-				Dest[i] = WordType((Dest[i] & ~Mask) | WordType(Word << UDestBit));
-				Dest[i + 1] = WordType((Dest[i + 1] & Mask) | WordType(Word >> UDestCopyBits));
+				const WordType Word = LoadWordUnaligned(&Src[i]);
+				const WordType D0 = LoadWordUnaligned(&Dest[i]);
+				const WordType D1 = LoadWordUnaligned(&Dest[i + 1]);
+				StoreWordUnaligned(&Dest[i], WordType((D0 & ~Mask) | WordType(Word << UDestBit)));
+				StoreWordUnaligned(&Dest[i + 1], WordType((D1 & Mask) | WordType(Word >> UDestCopyBits)));
 			}
 		}
 		Src += LoopCount;


### PR DESCRIPTION
## Summary

After PR #6 fixed the `FMath::Min` dangling-reference bug in
`CI/ue_shim.h`, the Sanitizers job could finally run past its initial
SUAR abort -- and immediately surfaced the next latent issue on `main`:

```
BitCopyFast.cpp:133:20: runtime error: load of misaligned address
0x521000000101 for type 'long unsigned int', which requires 8 byte alignment
```

This PR fixes exactly that report, and *only* that report.

## Root cause

`BitsCopyFastUnaligned` aligns its leading bits a byte at a time on
`uint8* Src` / `uint8* Dest`, then hands the remaining (only
guaranteed to be *byte*-aligned) pointers to `CopyBitsSrcAligned`
after an unconditional cast to `uint64*`:

```cpp
CopyBitsSrcAligned((uint64*)Dest, DestBit, (uint64*)Src, BitCount);
```

`CopyBitsSrcAligned` then dereferences them in its middle-word loop:

```cpp
const WordType Word = Src[i];                                       // load
Dest[i]     = WordType((Dest[i]     & ~Mask) | (Word << UDestBit)); // r/m/w
Dest[i + 1] = WordType((Dest[i + 1] &  Mask) | (Word >> UDestCopy));// r/m/w
```

On x86/x64 and arm64 the CPU happily services misaligned 8-byte loads
(which is exactly what `PLATFORM_SUPPORTS_UNALIGNED_LOADS=1`
promises), so the code is *functionally* correct and every
non-sanitized CI job has been green. But per the C++ standard, loading
a `uint64` through a `uint64*` that isn't 8-byte aligned is UB, and
UBSan's `-fsanitize=alignment` -- on by default in our Sanitizers
job -- is specifically there to catch it. The failure was previously
masked: the SUAR crash from the shim bug aborted sanitized runs
inside `BitsCopyFastUnaligned` before execution could ever reach this
load. PR #6 removed the earlier crash, so this pre-existing bug
became visible.

## Fix

Wrap the `WordType`-sized loads and stores in sizeof-bounded
`std::memcpy`:

```cpp
template <typename WordType>
static FORCEINLINE WordType LoadWordUnaligned(const WordType *P)
{
    WordType W;
    std::memcpy(&W, P, sizeof(W));
    return W;
}
template <typename WordType>
static FORCEINLINE void StoreWordUnaligned(WordType *P, WordType W)
{
    std::memcpy(P, &W, sizeof(W));
}
```

Clang, GCC and MSVC at `-O1` and above all fold a sizeof-bounded
`memcpy` of a trivially-copyable scalar down to a single machine
`mov` (or the arch's equivalent unaligned-load insn on arm64). So on
any platform with `PLATFORM_SUPPORTS_UNALIGNED_LOADS=1` the runtime
cost is identical to the raw `*p` dereference -- the difference is
strictly in what the standard and UBSan consider well-defined.

`CopyBitsSrcAligned`'s middle-word loops now use these wrappers; the
tail-byte handling, `BitsCopyFastAligned`, `BitsCopyFastUnaligned`,
and the `OriginalAppBitsCpy` reference are untouched.

## What this PR intentionally does NOT do

The translation unit still carries a defensive layer accumulated
while we were chasing the (now-understood) shim bug:

* `FASTBITCOPY_COMPILER_BARRIER()` between the byte-store prologue
  and the word-access loop
* `FASTBITCOPY_NOINLINE` on every hot helper
* `FASTBITCOPY_SAFE_OPT` (`__attribute__((optnone))` on Clang /
  `optimize("O0")` on GCC) on those same helpers
* Manual `uint32` promotion of shift operands in a handful of places

Each of these was added believing it was treating a real GCC/Clang
`-O2` miscompile. That belief has since been falsified -- the real
bug lived in `CI/ue_shim.h` and was fixed in #6. But "the stated
reason no longer applies" is not the same as "safe to remove"; the
barriers and the `noinline` in particular might still be doing useful
work for strict-aliasing / DSE reasons unrelated to the shim bug.

Unwinding them in the same PR as this alignment fix would mean that
if anything regresses we cannot tell whether the alignment rewrite or
the defense removal is at fault. So this PR keeps the defensive
layer exactly as it is on `main`, and follow-up PRs will peel it
back one attribute at a time with CI verification between each
step. The planned sequence is in PR #6's description.

## Expected CI impact

| Job | Before (`main` = f87b09f) | After (this PR) |
| --- | --- | --- |
| Sanitizers (ubuntu-latest) | :x: (alignment UB) | :white_check_mark: |
| Standalone test ubuntu-latest  -O2  | :white_check_mark: | :white_check_mark: |
| Standalone test macos-latest   -O2  | :white_check_mark: | :white_check_mark: |
| Standalone test windows-latest MSVC | :white_check_mark: | :white_check_mark: |
| Standalone test -O0 (ubuntu/macos) | :white_check_mark: | :white_check_mark: |
| arm64 cross-build (linux) | :white_check_mark: | :white_check_mark: |
| .uplugin validation | :white_check_mark: | :white_check_mark: |

With this PR merged, every CI job on `main` should be green -- at
which point we can start removing the defensive layer.

## Diff size

1 file, +36 / -4.
