### PR TITLE
docs: reflect Linux/macOS parity now that standalone Release CI is green

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,30 @@ x86-64 and arm64 we can do much better with aligned 64-bit loads/stores plus
 
 |            | Windows | Linux | macOS |
 |------------|:-------:|:-----:|:-----:|
-| **x86-64** |   ✅    |  🟡   |  🟡   |
-| **arm64**  |   ✅    |  🟡   |  🟡 (Apple Silicon) |
+| **x86-64** |   ✅    |  ✅   |  ✅   |
+| **arm64**  |   ✅    |  ✅   |  ✅ (Apple Silicon) |
 
 Requires a little-endian CPU that allows unaligned loads
 (`PLATFORM_LITTLE_ENDIAN && PLATFORM_SUPPORTS_UNALIGNED_LOADS`). Both x64
 and arm64 qualify.
 
-> **🟡 Partial optimization on Linux/macOS** — on Windows (MSVC) both the
-> byte-aligned and bit-unaligned paths use the optimized implementation
-> (~30× / ~5×). On Linux (GCC) and macOS (Clang) at `-O2`, only the
-> byte-aligned path is optimized; the bit-unaligned path falls back to
-> UE's stock `appBitsCpy` because of a compiler optimization interaction
-> we are still tracking. See
-> [#2](https://github.com/chen3feng/FastBitCopy/issues/2). Behaviour is
-> always correct — the worst case is "as fast as stock UE".
+> **Cross-platform correctness.** Both the byte-aligned and bit-unaligned
+> fast paths are compiled and exercised on all three host OSes in CI —
+> standalone `-O2` (MSVC, GCC, Clang), an additional `-O0` sweep on
+> Linux/macOS, and an UBSan+ASan run on Linux — and each covers the
+> 10 000-trial randomized correctness suite plus the page-boundary /
+> deterministic edge cases. The speed-up figures in the table above were
+> measured on Windows (MSVC); absolute numbers on Linux/macOS will vary
+> with compiler and host CPU, but the implementation path is the same.
+>
+> History note: issue
+> [#2](https://github.com/chen3feng/FastBitCopy/issues/2) tracked an
+> earlier `-O2` divergence on GCC/Clang that was resolved before the
+> standalone CI job became blocking. The current GCC/Clang build carries
+> a small set of defensive compile-time barriers (`FASTBITCOPY_NOINLINE`,
+> an inline-asm `"memory"` barrier, and an `optnone` wrapper around the
+> unaligned bulk copy) which we plan to peel back one at a time in
+> follow-up PRs, re-verifying CI at each step.
 
 ## Installation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -50,19 +50,28 @@ UE 自带的 `appBitsCpy` 是逐字节处理的标量实现。在 x86-64 与 arm
 
 |            | Windows | Linux | macOS |
 |------------|:-------:|:-----:|:-----:|
-| **x86-64** |   ✅    |  🟡   |  🟡   |
-| **arm64**  |   ✅    |  🟡   |  🟡（Apple Silicon） |
+| **x86-64** |   ✅    |  ✅   |  ✅   |
+| **arm64**  |   ✅    |  ✅   |  ✅（Apple Silicon） |
 
 需要满足 `PLATFORM_LITTLE_ENDIAN && PLATFORM_SUPPORTS_UNALIGNED_LOADS`
 （x64、arm64 都满足）。
 
-> **🟡 Linux / macOS 部分优化** —— Windows（MSVC）上字节对齐和位不对齐
-> 两条路径都走优化实现（~30× / ~5×）。Linux（GCC）和 macOS（Clang）在
-> `-O2` 下，只有字节对齐路径走优化实现；位不对齐路径回退到 UE 原版
-> `appBitsCpy`，这是因为编译器优化与我们算法之间还有一个尚未定位的
-> 相互作用问题，见
-> [#2](https://github.com/chen3feng/FastBitCopy/issues/2)。
-> 行为始终正确 —— 最差情况下和 UE 原版一样快。
+> **跨平台正确性。** 三大主机 OS 上 CI 都会在 `-O2` 下（MSVC / GCC /
+> Clang）编译并运行字节对齐与位不对齐两条快速路径，外加 Linux/macOS
+> 的 `-O0` 对照扫、以及 Linux 上的一次 UBSan + ASan 专项，每项都覆盖
+> 10 000 组随机 `(SrcBit, DstBit, BitCount)` 正确性测试和页边界 /
+> 确定性边界用例。上面表中的加速比是在 Windows (MSVC) 上测得，
+> Linux/macOS 上的绝对数字会随编译器和宿主 CPU 不同而变化，但走的
+> 是同一条优化实现路径。
+>
+> 历史记录：Issue
+> [#2](https://github.com/chen3feng/FastBitCopy/issues/2) 跟踪过早期
+> GCC/Clang `-O2` 下位不对齐路径与引用实现不一致的问题，在
+> standalone CI job 转为阻塞门禁之前已得到解决。当前 GCC/Clang 构建
+> 带有一小组防御性编译时屏障（`FASTBITCOPY_NOINLINE`、一条
+> `"memory"` 内联汇编屏障、以及对 unaligned bulk 段的 `optnone`
+> 包装），我们会在后续 PR 中按影响由小到大逐个拆除，每一步都会在
+> CI 中重新验证。
 
 ## 安装
 


### PR DESCRIPTION
## Summary

README (EN + CN) still carries the Issue #2 era caveat — "🟡 partial
optimization on Linux/macOS, bit-unaligned path falls back to stock
UE `appBitsCpy` at -O2" — which is no longer true.

As of PRs #6 and #7:

* Issue [#2](https://github.com/chen3feng/FastBitCopy/issues/2) is
  **CLOSED**.
* The `standalone-test` CI job runs `-O2` on Ubuntu, Windows and macOS
  as a **blocking** check (no `continue-on-error`) and exercises the
  full randomized 10 000-trial `Correctness` suite plus `PageBound` and
  deterministic edge cases for *both* the byte-aligned and
  bit-unaligned fast paths.
* The `sanitizers` job (UBSan + ASan on Linux) is also green after #7.

## Changes

* `README.md` — Linux/macOS cells go from 🟡 to ✅; the caveat block is
  replaced with a "Cross-platform correctness" note that explicitly
  scopes the `~30× / ~5×` numbers to Windows (MSVC), since they were
  never measured on Linux/macOS and the absolute values will differ by
  compiler and host CPU.
* `README_CN.md` — symmetric rewrite, same wording in Chinese.

## What is *not* claimed

I deliberately did **not** claim that the three defensive compile-time
barriers are unnecessary — the new paragraph calls them out by name
(`FASTBITCOPY_NOINLINE`, the inline-asm `"memory"` barrier, the
`optnone` wrapper around the unaligned bulk copy) and states that
follow-up PRs will peel them back one at a time with CI re-verification
at each step. That matches the real plan (F2a / F2b / F2c).

## What is *not* in this PR

* No source, `.Build.cs`, CMake or CI workflow changes.
* The "Known issue: on GCC/Clang -O2 the algorithm produces results
  that diverge from the reference" comment in `ci.yml` (above the
  `standalone-test-debug` job) is also stale but I left it for the
  first F2 PR, where I'll be touching that workflow anyway so the
  rewording fits the diff better.

## Verification

`docs-only` change. CI should be green trivially; if the badge or any
markdown renderer disagrees, I'll fix it before merge.
