### PR TITLE
refactor: remove FASTBITCOPY_SAFE_OPT per-function -O0 override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,11 @@ jobs:
       - name: Run correctness + micro-benchmark
         run: ctest --test-dir CI/build --output-on-failure -C Release
 
-  # Known issue: on GCC/Clang -O2 the algorithm produces results that
-  # diverge from the reference implementation. Until that is resolved,
-  # also run an -O0 sweep on Linux/macOS so CI can still detect
-  # regressions in the algorithm's overall logic.
+  # The GCC/Clang -O2 divergence tracked in issue #2 was resolved by
+  # PR #6 (FMath::Min dangling-ref) and PR #7 (alignment UB). The -O0
+  # sweep is kept as an extra safety net: if a future change introduces
+  # a new optimiser-sensitive bug, the -O0 job will stay green and help
+  # narrow the root cause.
   standalone-test-debug:
     name: Standalone test -O0 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ and arm64 qualify.
 > History note: issue
 > [#2](https://github.com/chen3feng/FastBitCopy/issues/2) tracked an
 > earlier `-O2` divergence on GCC/Clang that was resolved before the
-> standalone CI job became blocking. The current GCC/Clang build carries
-> a small set of defensive compile-time barriers (`FASTBITCOPY_NOINLINE`,
-> an inline-asm `"memory"` barrier, and an `optnone` wrapper around the
-> unaligned bulk copy) which we plan to peel back one at a time in
-> follow-up PRs, re-verifying CI at each step.
+> standalone CI job became blocking. The root causes were a
+> dangling-reference bug in the CI shim's `FMath::Min`/`Max` (PR #6)
+> and an alignment-UB in `CopyBitsSrcAligned` (PR #7). The per-function
+> `optnone`/`optimize("O0")` override (`FASTBITCOPY_SAFE_OPT`) has been
+> removed; two lighter defensive barriers remain (`FASTBITCOPY_NOINLINE`
+> and an inline-asm `"memory"` compiler barrier) and will be peeled back
+> in follow-up PRs, re-verifying CI at each step.
 
 ## Installation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -67,11 +67,12 @@ UE 自带的 `appBitsCpy` 是逐字节处理的标量实现。在 x86-64 与 arm
 > 历史记录：Issue
 > [#2](https://github.com/chen3feng/FastBitCopy/issues/2) 跟踪过早期
 > GCC/Clang `-O2` 下位不对齐路径与引用实现不一致的问题，在
-> standalone CI job 转为阻塞门禁之前已得到解决。当前 GCC/Clang 构建
-> 带有一小组防御性编译时屏障（`FASTBITCOPY_NOINLINE`、一条
-> `"memory"` 内联汇编屏障、以及对 unaligned bulk 段的 `optnone`
-> 包装），我们会在后续 PR 中按影响由小到大逐个拆除，每一步都会在
-> CI 中重新验证。
+> standalone CI job 转为阻塞门禁之前已得到解决。根本原因是 CI shim
+> 中 `FMath::Min`/`Max` 的悬垂引用（PR #6）以及 `CopyBitsSrcAligned`
+> 中的对齐 UB（PR #7）。逐函数 `optnone`/`optimize("O0")` 覆盖
+> （`FASTBITCOPY_SAFE_OPT`）已被移除；剩余两道较轻的防御屏障
+> （`FASTBITCOPY_NOINLINE` 和一条 `"memory"` 内联汇编屏障）将在后续
+> PR 中逐个拆除，每一步都会在 CI 中重新验证。
 
 ## 安装
 

--- a/Source/FastBitCopy/Private/BitCopyFast.cpp
+++ b/Source/FastBitCopy/Private/BitCopyFast.cpp
@@ -39,27 +39,18 @@
 #define FASTBITCOPY_NOINLINE
 #endif
 
-// Per-function optimization override. On GCC/Clang at -O2 we have observed
-// miscompilations in this translation unit (uninitialised-stack-slot loads
-// in the generated assembly; see #2). Compile the hot helpers at -O0
-// (which we *know* produces correct code from the -O0 CI jobs), while the
-// rest of the translation unit stays at the project-level -O2. The inner
-// loops are still a single memcpy in the aligned case; the unaligned
-// case loses some of its vectorisation but the rest of this TU (the
-// Original* reference and the hook plumbing) can still be optimized
-// normally.
-#if defined(__clang__)
-#define FASTBITCOPY_SAFE_OPT __attribute__((optnone))
-#elif defined(__GNUC__)
-#define FASTBITCOPY_SAFE_OPT __attribute__((optimize("O0")))
-#else
-#define FASTBITCOPY_SAFE_OPT
-#endif
+// FASTBITCOPY_SAFE_OPT was a per-function optimization override that
+// compiled the hot helpers at -O0 on GCC/Clang to work around a
+// miscompilation observed in issue #2. The root cause turned out to be
+// a dangling-reference bug in the CI shim's FMath::Min/Max (fixed in
+// PR #6) and an alignment-UB in CopyBitsSrcAligned (fixed in PR #7),
+// not a compiler bug. Removed: all functions now compile at the
+// project-level optimization (-O2 in Release).
 
 #if PLATFORM_LITTLE_ENDIAN && PLATFORM_SUPPORTS_UNALIGNED_LOADS
 
 // Copy bits when BitOffset of Src and Dest are same.
-static FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void BitsCopyFastAligned(uint8 *Dest, uint8 *Src, int BitOffset, int BitCount)
+static FASTBITCOPY_NOINLINE void BitsCopyFastAligned(uint8 *Dest, uint8 *Src, int BitOffset, int BitCount)
 {
 	// Copy leading bits: Align to byte boundary
 	if (BitOffset != 0)
@@ -126,7 +117,7 @@ static FORCEINLINE void StoreWordUnaligned(WordType *P, WordType W)
 
 // Copy bits with source bit offset aligned.
 template <typename WordType>
-static FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void CopyBitsSrcAligned(WordType *Dest, int DestBit, WordType *Src, int BitCount)
+static FASTBITCOPY_NOINLINE void CopyBitsSrcAligned(WordType *Dest, int DestBit, WordType *Src, int BitCount)
 {
 	// Handle middle words
 	const int BitsPerWord = sizeof(WordType) * 8;
@@ -206,7 +197,7 @@ static FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void CopyBitsSrcAligned(WordTyp
 	}
 }
 
-static FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void BitsCopyFastUnaligned(uint8 *Dest, int DestBit, uint8 *Src, int SrcBit, int BitCount)
+static FASTBITCOPY_NOINLINE void BitsCopyFastUnaligned(uint8 *Dest, int DestBit, uint8 *Src, int SrcBit, int BitCount)
 {
 	// Align SrcBit to 0
 	if (SrcBit != 0)
@@ -368,7 +359,7 @@ void OriginalAppBitsCpyForTest(uint8* Dest, int32 DestBit, uint8* Src, int32 Src
 }
 
 // Our optimized bit copy entry point.
-FASTBITCOPY_NOINLINE FASTBITCOPY_SAFE_OPT void appBitsCpyFastImpl(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount)
+FASTBITCOPY_NOINLINE void appBitsCpyFastImpl(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount)
 {
 	// Align to byte bound.
 	Dest += DestBit / 8;


### PR DESCRIPTION
## Summary

Remove the `FASTBITCOPY_SAFE_OPT` per-function optimization override
(`optnone` on Clang, `optimize("O0")` on GCC) that was added as a
workaround for issue #2.

The root causes of the -O2 divergence have since been identified and
fixed:

* **PR #6** — `FMath::Min`/`Max` in the CI shim returned a dangling
  reference (the template deduced `T&` from the ternary operator).
* **PR #7** — `CopyBitsSrcAligned` performed unaligned `uint64*`
  dereferences that UBSan correctly flagged; replaced with
  `memcpy`-based `LoadWordUnaligned`/`StoreWordUnaligned`.

With both fixes in place, the per-function -O0 override is no longer
needed. All four annotated functions now compile at the project-level
optimization setting.

## Changes

| File | What |
|------|------|
| `BitCopyFast.cpp` | Remove `FASTBITCOPY_SAFE_OPT` definition and all 4 usages |
| `ci.yml` | Replace stale "Known issue" comment with resolved-by note |
| `README.md` | Note SAFE_OPT removal; list remaining 2 barriers |
| `README_CN.md` | Symmetric Chinese update |

## Remaining defensive barriers

Two lighter barriers are still in place and will be addressed in
follow-up PRs:

1. **`FASTBITCOPY_NOINLINE`** — prevents inlining of the hot entry
   points, which was observed to enable aggressive interprocedural
   dead-store elimination on GCC.
2. **`FASTBITCOPY_COMPILER_BARRIER()`** — an inline-asm `"memory"`
   clobber between the `uint8*` leading-byte fixup and the `uint64*`
   bulk copy in `BitsCopyFastUnaligned`.

## Verification

This is the critical PR in the F2 series: if the -O0 override was
actually masking a real compiler bug (rather than the two shim/UB
issues we fixed), the `-O2` standalone tests on Ubuntu and macOS will
fail. **CI must be all-green before merge.**
