### PR TITLE
refactor: remove FASTBITCOPY_NOINLINE defensive barrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ and arm64 qualify.
 > standalone CI job became blocking. The root causes were a
 > dangling-reference bug in the CI shim's `FMath::Min`/`Max` (PR #6)
 > and an alignment-UB in `CopyBitsSrcAligned` (PR #7). The per-function
-> `optnone`/`optimize("O0")` override (`FASTBITCOPY_SAFE_OPT`) has been
-> removed; two lighter defensive barriers remain (`FASTBITCOPY_NOINLINE`
-> and an inline-asm `"memory"` compiler barrier) and will be peeled back
-> in follow-up PRs, re-verifying CI at each step.
+> `optnone`/`optimize("O0")` override and the `noinline` attribute have
+> both been removed (PRs #9 and #10). One lightweight defensive barrier
+> remains — an inline-asm `"memory"` compiler barrier between the
+> leading-byte `uint8*` fixup and the `uint64*` bulk copy — and will be
+> removed in a follow-up PR once verified.
 
 ## Installation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -69,10 +69,10 @@ UE 自带的 `appBitsCpy` 是逐字节处理的标量实现。在 x86-64 与 arm
 > GCC/Clang `-O2` 下位不对齐路径与引用实现不一致的问题，在
 > standalone CI job 转为阻塞门禁之前已得到解决。根本原因是 CI shim
 > 中 `FMath::Min`/`Max` 的悬垂引用（PR #6）以及 `CopyBitsSrcAligned`
-> 中的对齐 UB（PR #7）。逐函数 `optnone`/`optimize("O0")` 覆盖
-> （`FASTBITCOPY_SAFE_OPT`）已被移除；剩余两道较轻的防御屏障
-> （`FASTBITCOPY_NOINLINE` 和一条 `"memory"` 内联汇编屏障）将在后续
-> PR 中逐个拆除，每一步都会在 CI 中重新验证。
+> 中的对齐 UB（PR #7）。逐函数 `optnone`/`optimize("O0")` 覆盖和
+> `noinline` 属性均已移除（PR #9 和 #10）。剩余一道轻量防御屏障——
+> 前导字节 `uint8*` 修正与 `uint64*` 批量拷贝之间的内联汇编
+> `"memory"` 编译器屏障——将在验证后的后续 PR 中移除。
 
 ## 安装
 

--- a/Source/FastBitCopy/Private/BitCopyFast.cpp
+++ b/Source/FastBitCopy/Private/BitCopyFast.cpp
@@ -25,19 +25,12 @@
 #define FASTBITCOPY_COMPILER_BARRIER() std::atomic_thread_fence(std::memory_order_seq_cst)
 #endif
 
-// Prevent inlining of the top-level entry points. If GCC/Clang inlines
-// BitsCopyFastUnaligned into appBitsCpyFastImpl and then into a caller
-// whose output it can statically see, the aggressive interprocedural
-// dead-store elimination can delete the whole thing (observed on
-// Linux -O2). Keeping the hot functions in their own frame shuts that
-// path down with no measurable runtime cost on the bulk workload.
-#if defined(__GNUC__) || defined(__clang__)
-#define FASTBITCOPY_NOINLINE __attribute__((noinline))
-#elif defined(_MSC_VER)
-#define FASTBITCOPY_NOINLINE __declspec(noinline)
-#else
-#define FASTBITCOPY_NOINLINE
-#endif
+// FASTBITCOPY_NOINLINE was a defensive noinline attribute added to prevent
+// GCC/Clang from inlining the hot functions into callers and then applying
+// aggressive interprocedural dead-store elimination. The root causes of
+// the observed -O2 divergence turned out to be a dangling-reference bug
+// in FMath::Min/Max (PR #6) and alignment UB (PR #7), not an inlining
+// issue. Removed: the compiler is now free to inline as it sees fit.
 
 // FASTBITCOPY_SAFE_OPT was a per-function optimization override that
 // compiled the hot helpers at -O0 on GCC/Clang to work around a
@@ -50,7 +43,7 @@
 #if PLATFORM_LITTLE_ENDIAN && PLATFORM_SUPPORTS_UNALIGNED_LOADS
 
 // Copy bits when BitOffset of Src and Dest are same.
-static FASTBITCOPY_NOINLINE void BitsCopyFastAligned(uint8 *Dest, uint8 *Src, int BitOffset, int BitCount)
+static void BitsCopyFastAligned(uint8 *Dest, uint8 *Src, int BitOffset, int BitCount)
 {
 	// Copy leading bits: Align to byte boundary
 	if (BitOffset != 0)
@@ -117,7 +110,7 @@ static FORCEINLINE void StoreWordUnaligned(WordType *P, WordType W)
 
 // Copy bits with source bit offset aligned.
 template <typename WordType>
-static FASTBITCOPY_NOINLINE void CopyBitsSrcAligned(WordType *Dest, int DestBit, WordType *Src, int BitCount)
+static void CopyBitsSrcAligned(WordType *Dest, int DestBit, WordType *Src, int BitCount)
 {
 	// Handle middle words
 	const int BitsPerWord = sizeof(WordType) * 8;
@@ -197,7 +190,7 @@ static FASTBITCOPY_NOINLINE void CopyBitsSrcAligned(WordType *Dest, int DestBit,
 	}
 }
 
-static FASTBITCOPY_NOINLINE void BitsCopyFastUnaligned(uint8 *Dest, int DestBit, uint8 *Src, int SrcBit, int BitCount)
+static void BitsCopyFastUnaligned(uint8 *Dest, int DestBit, uint8 *Src, int SrcBit, int BitCount)
 {
 	// Align SrcBit to 0
 	if (SrcBit != 0)
@@ -257,17 +250,10 @@ static FASTBITCOPY_NOINLINE void BitsCopyFastUnaligned(uint8 *Dest, int DestBit,
 // ----------------------------------------------------------------------------
 // Original appBitsCpy (kept verbatim for benchmarking & as a fallback reference)
 // ----------------------------------------------------------------------------
-// NOTE: we deliberately do NOT FORCEINLINE this on GCC/Clang. Inlining it
-// into appBitsCpyFastImpl turned out to expose a codegen bug on Linux
-// GCC -O2 (see issue #2 / uninitialised-stack-slot analysis) that
-// manifested as a SegFault in CI when we used this function as the
-// non-MSVC fallback for the unaligned path.
-#if defined(_MSC_VER)
-#define FASTBITCOPY_ORIG_INLINE FORCEINLINE
-#else
-#define FASTBITCOPY_ORIG_INLINE FASTBITCOPY_NOINLINE
-#endif
-static FASTBITCOPY_ORIG_INLINE void OriginalAppBitsCpy(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount)
+// The original appBitsCpy reference implementation. FORCEINLINE on all
+// platforms: it is only called from OriginalAppBitsCpyForTest (benchmark
+// harness) and the compiler can decide whether to actually inline it.
+static FORCEINLINE void OriginalAppBitsCpy(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount)
 {
 	if (BitCount <= 8)
 	{
@@ -359,7 +345,7 @@ void OriginalAppBitsCpyForTest(uint8* Dest, int32 DestBit, uint8* Src, int32 Src
 }
 
 // Our optimized bit copy entry point.
-FASTBITCOPY_NOINLINE void appBitsCpyFastImpl(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount)
+void appBitsCpyFastImpl(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount)
 {
 	// Align to byte bound.
 	Dest += DestBit / 8;


### PR DESCRIPTION
## Summary

Remove the `FASTBITCOPY_NOINLINE` defensive barrier — the second of the
three compile-time workarounds added for issue #2.

PR #9 already proved that removing the per-function `-O0` override
(`FASTBITCOPY_SAFE_OPT`) leaves CI green on all platforms at `-O2`.
This PR goes one step further and allows the compiler to inline the hot
functions freely.

## Changes

| File | What |
|------|------|
| `BitCopyFast.cpp` | Remove `FASTBITCOPY_NOINLINE` definition and all 4 usages; remove `FASTBITCOPY_ORIG_INLINE` conditional (use `FORCEINLINE` on all platforms) |
| `README.md` | Note NOINLINE removal; list only the remaining compiler barrier |
| `README_CN.md` | Symmetric Chinese update |

## Remaining defensive barrier

One barrier remains:

* **`FASTBITCOPY_COMPILER_BARRIER()`** — an inline-asm `"memory"`
  clobber between the `uint8*` leading-byte fixup and the `uint64*`
  bulk copy in `BitsCopyFastUnaligned`. This will be addressed in the
  next (and final) follow-up PR.

## Verification

If inlining was actually the trigger for the dead-store elimination
issue (as the old comment claimed), the `-O2` standalone tests on
Ubuntu and macOS will fail. **CI must be all-green before merge.**
