### PR TITLE
refactor: remove FASTBITCOPY_COMPILER_BARRIER (final defensive layer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ and arm64 qualify.
 > earlier `-O2` divergence on GCC/Clang that was resolved before the
 > standalone CI job became blocking. The root causes were a
 > dangling-reference bug in the CI shim's `FMath::Min`/`Max` (PR #6)
-> and an alignment-UB in `CopyBitsSrcAligned` (PR #7). The per-function
-> `optnone`/`optimize("O0")` override and the `noinline` attribute have
-> both been removed (PRs #9 and #10). One lightweight defensive barrier
-> remains — an inline-asm `"memory"` compiler barrier between the
-> leading-byte `uint8*` fixup and the `uint64*` bulk copy — and will be
-> removed in a follow-up PR once verified.
+> and an alignment-UB in `CopyBitsSrcAligned` (PR #7). All three
+> defensive compile-time barriers that were added as workarounds
+> (`FASTBITCOPY_SAFE_OPT`, `FASTBITCOPY_NOINLINE`, and the inline-asm
+> `"memory"` compiler barrier) have since been removed (PRs #9, #10,
+> #11) with CI remaining green at each step, confirming the fixes
+> addressed the true root causes.
 
 ## Installation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -69,10 +69,10 @@ UE 自带的 `appBitsCpy` 是逐字节处理的标量实现。在 x86-64 与 arm
 > GCC/Clang `-O2` 下位不对齐路径与引用实现不一致的问题，在
 > standalone CI job 转为阻塞门禁之前已得到解决。根本原因是 CI shim
 > 中 `FMath::Min`/`Max` 的悬垂引用（PR #6）以及 `CopyBitsSrcAligned`
-> 中的对齐 UB（PR #7）。逐函数 `optnone`/`optimize("O0")` 覆盖和
-> `noinline` 属性均已移除（PR #9 和 #10）。剩余一道轻量防御屏障——
-> 前导字节 `uint8*` 修正与 `uint64*` 批量拷贝之间的内联汇编
-> `"memory"` 编译器屏障——将在验证后的后续 PR 中移除。
+> 中的对齐 UB（PR #7）。作为临时方案添加的三道防御性编译时屏障
+> （`FASTBITCOPY_SAFE_OPT`、`FASTBITCOPY_NOINLINE`、内联汇编
+> `"memory"` 编译器屏障）已全部移除（PR #9、#10、#11），每一步 CI
+> 均保持全绿，确认修复针对的是真正的根因。
 
 ## 安装
 

--- a/Source/FastBitCopy/Private/BitCopyFast.cpp
+++ b/Source/FastBitCopy/Private/BitCopyFast.cpp
@@ -7,23 +7,16 @@
 #include "BitCopyFast.h"
 #include "CoreMinimal.h"
 #include "Math/UnrealMathUtility.h"
-#include <atomic>
 #include <cstring>
 
-// A *real* compiler barrier. std::atomic_signal_fence turned out to be
-// insufficient on Clang/GCC -O2 (it disciplines reorderings with respect to
-// signal handlers, but doesn't stop the optimizer from concluding that a
-// uint8* store cannot affect a subsequent uint64* read). An inline-asm
-// memory clobber, on the other hand, forces the compiler to treat every
-// reachable memory location as potentially read/written.
-#if defined(__GNUC__) || defined(__clang__)
-#define FASTBITCOPY_COMPILER_BARRIER() __asm__ __volatile__("" ::: "memory")
-#elif defined(_MSC_VER)
-#include <intrin.h>
-#define FASTBITCOPY_COMPILER_BARRIER() _ReadWriteBarrier()
-#else
-#define FASTBITCOPY_COMPILER_BARRIER() std::atomic_thread_fence(std::memory_order_seq_cst)
-#endif
+// FASTBITCOPY_COMPILER_BARRIER was an inline-asm "memory" clobber placed
+// between the uint8* leading-byte fixup and the uint64* bulk copy in
+// BitsCopyFastUnaligned. It was added under the hypothesis that GCC/Clang
+// were eliding the uint8* stores because they assumed no aliasing with
+// the subsequent uint64* reads. The actual root causes turned out to be
+// a dangling-reference bug in FMath::Min/Max (PR #6) and alignment UB
+// (PR #7). PRs #9 and #10 removed the other two barriers with CI staying
+// green, confirming the hypothesis was wrong. Removed.
 
 // FASTBITCOPY_NOINLINE was a defensive noinline attribute added to prevent
 // GCC/Clang from inlining the hot functions into callers and then applying
@@ -239,11 +232,6 @@ static void BitsCopyFastUnaligned(uint8 *Dest, int DestBit, uint8 *Src, int SrcB
 		++Src;
 		SrcBit = 0;
 	}
-	// Compiler barrier: GCC/Clang otherwise aggressively elide our uint8*
-	// stores above on the assumption they don't alias the uint64* reads that
-	// follow. This is a pure compile-time fence (no runtime cost) that
-	// forces the compiler to keep them.
-	FASTBITCOPY_COMPILER_BARRIER();
 	CopyBitsSrcAligned((uint64*)Dest, DestBit, (uint64*)Src, BitCount);
 }
 


### PR DESCRIPTION
## Summary

Remove the last defensive barrier: the inline-asm memory clobber in
`BitsCopyFastUnaligned`.

PRs #9 and #10 already proved that removing `optnone` and `noinline`
leaves CI green. This PR completes the cleanup by removing the compiler
barrier and the now-unused `#include <atomic>`.

After this, `BitCopyFast.cpp` contains **zero** defensive workarounds
and compiles with full optimization on all three platforms.

## Changes

| File | What |
|------|------|
| `BitCopyFast.cpp` | Remove `COMPILER_BARRIER` definition (3 variants) + usage + unused `<atomic>` include |
| `README.md` | Note all barriers removed |
| `README_CN.md` | Symmetric Chinese update |

## Verification

This is the highest-risk removal in the F2 series: if the aliasing
hypothesis was correct (`uint8*` stores being elided before `uint64*`
reads), the `-O2` tests will fail. **CI must be all-green before merge.**
