### PR TITLE
fix(FunctionHook): eliminate MSVC C4702 unreachable code in Install

### DIFF
--- a/Source/FastBitCopy/Private/FunctionHook.cpp
+++ b/Source/FastBitCopy/Private/FunctionHook.cpp
@@ -895,16 +895,13 @@ bool FFunctionHook::Install(void *Target, void *Detour, void **OutTrampoline)
 	if (bInstalled)
 		return false;
 
+#if PLATFORM_CPU_X86_FAMILY || PLATFORM_CPU_ARM_FAMILY
 #if PLATFORM_CPU_X86_FAMILY
 	const FInstallResult R = InstallHook_X64(Target, Detour);
-#elif PLATFORM_CPU_ARM_FAMILY
-	const FInstallResult R = InstallHook_Arm64(Target, Detour);
 #else
-	(void)Target; (void)Detour; (void)OutTrampoline;
-	return false;
+	const FInstallResult R = InstallHook_Arm64(Target, Detour);
 #endif
 
-#if PLATFORM_CPU_X86_FAMILY || PLATFORM_CPU_ARM_FAMILY
 	if (!R.bOk)
 		return false;
 
@@ -917,9 +914,13 @@ bool FFunctionHook::Install(void *Target, void *Detour, void **OutTrampoline)
 	if (OutTrampoline)
 		*OutTrampoline = TrampolineMem;
 	return true;
-#endif
-	// Unreachable on supported platforms; keeps the compiler happy.
+#else
+	// Unsupported CPU family — hook is a no-op.
+	(void)Target;
+	(void)Detour;
+	(void)OutTrampoline;
 	return false;
+#endif
 }
 bool FFunctionHook::Uninstall()
 {


### PR DESCRIPTION
## Summary

Fixes an MSVC `C4702 unreachable code` error that surfaces on a Windows x64
UE build of `TestHost`, originally introduced (inadvertently) by the
per-arch `Install` refactor in #15:

```
[6/10] Compile [x64] FunctionHook.cpp
.../FunctionHook.cpp(922) : error C4702: unreachable code
   while compiling FFunctionHook::Install
```

### Root cause

After #15, `FFunctionHook::Install` looked like this (simplified):

```cpp
#if PLATFORM_CPU_X86_FAMILY
    const FInstallResult R = InstallHook_X64(Target, Detour);
#elif PLATFORM_CPU_ARM_FAMILY
    const FInstallResult R = InstallHook_Arm64(Target, Detour);
#else
    (void)Target; (void)Detour; (void)OutTrampoline;
    return false;
#endif

#if PLATFORM_CPU_X86_FAMILY || PLATFORM_CPU_ARM_FAMILY
    if (!R.bOk) return false;
    ...
    return true;
#endif
    // Unreachable on supported platforms; keeps the compiler happy.
    return false;
}
```

On a Windows x64 build, `PLATFORM_CPU_X86_FAMILY == 1`, so after the
preprocessor pass MSVC sees:

```cpp
const FInstallResult R = InstallHook_X64(...);
if (!R.bOk) return false;
...
return true;
return false;   // <-- C4702: unreachable
```

The trailing `return false;` — intended as a safety net for exotic CPU
families — is provably unreachable on every arch we actually support, and
MSVC is right to warn. Under UE's default warning level (which promotes
this to an error), the build fails.

### Fix

Restructure the whole body into one balanced `#if / #else / #endif`, so
every preprocessor branch has exactly one return path and no trailing
unreachable statement:

```cpp
#if PLATFORM_CPU_X86_FAMILY || PLATFORM_CPU_ARM_FAMILY
    #if PLATFORM_CPU_X86_FAMILY
        const FInstallResult R = InstallHook_X64(Target, Detour);
    #else
        const FInstallResult R = InstallHook_Arm64(Target, Detour);
    #endif

    if (!R.bOk) return false;
    ...
    return true;
#else
    // Unsupported CPU family — hook is a no-op.
    (void)Target;
    (void)Detour;
    (void)OutTrampoline;
    return false;
#endif
```

Same end state for every supported arch, same no-op semantics on any
hypothetical unsupported arch, but MSVC no longer sees a dead `return`.

### Test Plan

- [x] `git grep` confirms `FunctionHook.cpp` now has a single `#if ... #else
      ... #endif` spanning the whole function; no stray statements after
      `#endif` inside `Install`.
- [ ] CI (GitHub Actions) green on all platforms.
- [ ] Local UE `TestHost` build on Windows x64 no longer errors with
      C4702 on `FunctionHook.cpp(922)`.

### Notes

- No behavioral change on x86_64 or aarch64.
- The em-dash (`—`) in the comment is intentionally preserved: the rest of
  `FunctionHook.cpp` and its peers use it throughout, so keeping it here
  matches existing source-code style. (PR #16 only removed em-dashes from
  `.bat` scripts because `cmd.exe` on GBK Windows mis-parsed them; this
  concern does not apply to UTF-8 C++ source.)
