### PR TITLE
fix(testhost): run automation via -Run=Automation commandlet to avoid macOS Cocoa menu crash

### DIFF
--- a/build_testhost.sh
+++ b/build_testhost.sh
@@ -125,9 +125,20 @@ if [[ "${TARGET_TYPE_LOWER}" == "test" ]]; then
     mkdir -p "${REPORT_DIR}"
 
     # Common flags for headless automation.
+    #
+    # We run tests via the Automation *commandlet* (-Run=Automation) rather than
+    # -ExecCmds=. The commandlet path drives UCommandlet::Main and never enters
+    # FEngineLoop::Tick / Slate tick / the Cocoa main-menu sync loop. This is
+    # what avoids the known macOS crash inside
+    #   FSlateMacMenu::UpdateWithMultiBox
+    # (an async NSRunLoop source0 block firing on a TSharedPtr<FMultiBox> that
+    # has already been destroyed during editor shutdown). The crash is a UE
+    # engine-side issue, not a FastBitCopy issue; -Run=Automation sidesteps it
+    # entirely because the menu-sync path is never armed.
+    #
     # -NullRHI / -nosound / -nosplash keep us off all UI/audio subsystems.
-    # On macOS this also dodges a known crash in FSlateMacMenu::UpdateWithMultiBox
-    # (Cocoa main-menu sync on a dangling TSharedPtr) that surfaces in commandlet mode.
+    # -nop4 / -NoSourceControl stop the editor from trying Perforce/Git login.
+    # -unattended / -NoPause keep the process non-interactive on CI.
     COMMON_FLAGS=(
         -unattended
         -NoPause
@@ -139,15 +150,17 @@ if [[ "${TARGET_TYPE_LOWER}" == "test" ]]; then
         -log
     )
 
-    # Disable Mac's Cocoa main menu rebuild path where supported; harmless on Linux.
+    # On macOS, also skip Slate renderer construction. Combined with the
+    # commandlet launch path above this gives belt-and-braces protection
+    # against FSlateMacMenu touching any TSharedPtr owned by the editor UI.
     if [[ "${PLATFORM}" == "Mac" ]]; then
         COMMON_FLAGS+=( -NoSlateRenderer )
     fi
 
     set +e
     "${EDITOR_CMD}" "${PROJECT}" \
-        -ExecCmds="Automation RunTests FastBitCopy; Quit" \
-        -TestExit="Automation Test Queue Empty" \
+        -Run=Automation \
+        -TestCmds="RunTests FastBitCopy" \
         -ReportExportPath="${REPORT_DIR}" \
         "${COMMON_FLAGS[@]}"
     TEST_EXIT=$?

--- a/run_testhost.bat
+++ b/run_testhost.bat
@@ -122,7 +122,7 @@ echo [SKIP] UnrealEditor-Cmd.exe not found - cannot run automation tests
     set /a FAILURES+=1
     goto :SkipEditorTest
 )
-"%EDITOR_CMD%" "%PROJECT%" -ExecCmds="Automation RunTests FastBitCopy" -unattended -NoPause -NullRHI -log
+"%EDITOR_CMD%" "%PROJECT%" -Run=Automation -TestCmds="RunTests FastBitCopy" -unattended -NoPause -NullRHI -nosound -nosplash -nop4 -NoSourceControl -log
 if errorlevel 1 (
     echo.
     echo [FAIL] Editor automation tests failed
@@ -180,7 +180,7 @@ if not exist "%EDITOR_CMD%" (
     echo ERROR: UnrealEditor-Cmd.exe not found at %EDITOR_CMD%
     exit /b 1
 )
-"%EDITOR_CMD%" "%PROJECT%" -ExecCmds="Automation RunTests FastBitCopy" -unattended -NoPause -NullRHI -log
+"%EDITOR_CMD%" "%PROJECT%" -Run=Automation -TestCmds="RunTests FastBitCopy" -unattended -NoPause -NullRHI -nosound -nosplash -nop4 -NoSourceControl -log
 if errorlevel 1 (
     echo.
     echo [FAIL] Editor automation tests failed
@@ -236,7 +236,7 @@ if not exist "%EDITOR_CMD%" (
     echo ERROR: UnrealEditor-Cmd.exe not found at %EDITOR_CMD%
     exit /b 1
 )
-"%EDITOR_CMD%" "%PROJECT%" -ExecCmds="Automation RunTests FastBitCopy" -unattended -NoPause -NullRHI -log
+"%EDITOR_CMD%" "%PROJECT%" -Run=Automation -TestCmds="RunTests FastBitCopy" -unattended -NoPause -NullRHI -nosound -nosplash -nop4 -NoSourceControl -log
 if errorlevel 1 (
     echo.
     echo [FAIL] Editor automation tests failed


### PR DESCRIPTION
## Problem

On macOS the TestHost editor crashed during automation shutdown:

```
LogMac: Error: appError called: Assertion failed: IsValid() [File:Runtime/Core/Public/Templates/SharedPointer.h] [Line: 1128]
LogMac: === Critical error: ===
SIGSEGV: invalid attempt to access memory at address 0x3
0x09b2bc70 UnrealEditor-Slate.dylib!invocation function for block in FSlateMacMenu::UpdateWithMultiBox(TSharedPtr<FMultiBox, (ESPMode)1>)
0x06b6a770 UnrealEditor-Core.dylib!FCocoaRunLoopSource::Process(__CFString const*)
0x06b6a51c UnrealEditor-Core.dylib!-[FCocoaRunLoopSourceInfo perform]
...
```

A Cocoa `NSRunLoop` source0 block captures a `TSharedPtr<FMultiBox>`. By the time that block fires, the owning editor UI has already been torn down. The shared pointer's `IsValid()` assertion trips, taking down the process.

This reproduces only with `-ExecCmds="Automation RunTests ...; Quit"`, which drives the full `FEngineLoop::Tick` / Slate tick path, which in turn arms the Cocoa main-menu sync loop. It is an engine-side lifetime bug in Slate, not a FastBitCopy bug.

## Fix

Switch both the macOS/Linux and Windows test runners from:

```
-ExecCmds="Automation RunTests FastBitCopy; Quit" -TestExit="Automation Test Queue Empty"
```

to:

```
-Run=Automation -TestCmds="RunTests FastBitCopy"
```

`-Run=Automation` goes through `UCommandlet::Main` and never enters `FEngineLoop::Tick` / Slate tick / the Cocoa main-menu sync code, so the dangling `TSharedPtr<FMultiBox>` is never dereferenced.

Also:
- Add `-nosound -nosplash -nop4 -NoSourceControl` to the Windows invocations for parity and to keep the editor strictly non-interactive on CI.
- Keep `-NoSlateRenderer` on macOS as belt-and-braces (commandlet + no Slate renderer).

## Scope

Only `build_testhost.sh` and `run_testhost.bat`. No C++ / plugin code changes.
