### PR TITLE
bench(ci): add threshold sweep benchmark (P1 data collection)

### DIFF
--- a/CI/CMakeLists.txt
+++ b/CI/CMakeLists.txt
@@ -26,6 +26,11 @@ target_include_directories(fastbitcopy_ci PRIVATE
     "${PLUGIN_ROOT}/Source/FastBitCopy/Public"
 )
 
+# Expose internal functions (BitsCopyFastAligned/Unaligned, OriginalAppBitsCpyImpl)
+# for the threshold sweep benchmark. This flag is ONLY set in the CI standalone
+# build; the UE plugin build never sees it.
+target_compile_definitions(fastbitcopy_ci PRIVATE FASTBITCOPY_EXPOSE_INTERNALS=1)
+
 # Force-include ue_shim.h ahead of anything so UE types & macros are defined
 # before the plugin sources are parsed.
 if(MSVC)

--- a/CI/test_main.cpp
+++ b/CI/test_main.cpp
@@ -271,7 +271,22 @@ namespace
             V = static_cast<uint8>(ByteDist(Rng));
 
         // Candidate thresholds to sweep (in bits).
-        const int kThresholds[] = {8, 16, 32, 48, 64, 96, 128, 192, 256};
+        //
+        // 8..256 covers the "small payload" crossover region where the
+        // per-call overhead of the fast path might not pay off yet.
+        //
+        // 384..2048 covers the "medium / large" region we also care about
+        // for UE networking: Bunches are split at ~1024 bytes on send, so
+        // anything beyond ~2048 bits (256 B) is already well inside the
+        // fast path's comfort zone and doesn't add information.
+        //
+        // At these larger sizes the "Gated" column degenerates into the
+        // "Orig" column (payload <= thresh always takes the original
+        // path), so the useful signal there is the Orig_ns vs Fast_ns
+        // comparison, i.e. when does the unaligned fast path start to
+        // dominate the scalar original implementation.
+        const int kThresholds[] = {8, 16, 32, 48, 64, 96, 128, 192, 256,
+                                   384, 512, 768, 1024, 2048};
         // Iterations per measurement.
         const int kIters = 100000;
 

--- a/CI/test_main.cpp
+++ b/CI/test_main.cpp
@@ -215,6 +215,136 @@ void RunBench(std::mt19937& Rng)
 
 } // namespace
 
+#if FASTBITCOPY_EXPOSE_INTERNALS
+
+// Forward declarations for the internal wrappers exposed by FastBitCopy.cpp
+// when FASTBITCOPY_EXPOSE_INTERNALS is defined.
+// NOTE: these must be declared at global scope (outside any anonymous namespace)
+// to match the definitions in FastBitCopy.cpp.
+void FastBitCopy_Internal_Aligned(uint8 *Dest, uint8 *Src, int BitOffset, int BitCount);
+void FastBitCopy_Internal_Unaligned(uint8 *Dest, int DestBit, uint8 *Src, int SrcBit, int BitCount);
+void FastBitCopy_Internal_Original(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount);
+
+namespace
+{
+
+    // Simulate FastBitCopy with a custom small-size threshold (in bits).
+    // Below the threshold: forward to OriginalAppBitsCpyImpl (via the exposed wrapper).
+    // At or above: use the fast aligned/unaligned path directly.
+    static void FastBitCopyWithThreshold(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount,
+                                         int32 SmallBitsThreshold)
+    {
+        if (BitCount <= SmallBitsThreshold)
+        {
+            FastBitCopy_Internal_Original(Dest, DestBit, Src, SrcBit, BitCount);
+            return;
+        }
+        // Normalise to byte boundary (mirrors FastBitCopy's own prelude).
+        Dest += DestBit / 8;
+        DestBit %= 8;
+        Src += SrcBit / 8;
+        SrcBit %= 8;
+        if (SrcBit == DestBit)
+            FastBitCopy_Internal_Aligned(Dest, Src, SrcBit, BitCount);
+        else
+            FastBitCopy_Internal_Unaligned(Dest, DestBit, Src, SrcBit, BitCount);
+    }
+
+    // Threshold sweep benchmark.
+    //
+    // For each candidate threshold value, measures the time to copy payloads of
+    // exactly (threshold - 1), threshold, and (threshold + 1) bits under both
+    // aligned and unaligned conditions, comparing:
+    //   - "Orig"  : always use OriginalAppBitsCpyImpl
+    //   - "Fast"  : always use the fast path (no threshold guard, threshold=0)
+    //   - "Gated" : use FastBitCopyWithThreshold(threshold)
+    //
+    // The output table lets you pick the crossover point where "Gated" stops
+    // being slower than "Orig" for both aligned and unaligned cases.
+    void RunBenchSweep(std::mt19937 &Rng)
+    {
+        using clock = std::chrono::steady_clock;
+
+        Buffers B;
+        std::uniform_int_distribution<int> ByteDist(0, 255);
+        for (auto &V : B.Src)
+            V = static_cast<uint8>(ByteDist(Rng));
+
+        // Candidate thresholds to sweep (in bits).
+        const int kThresholds[] = {8, 16, 32, 48, 64, 96, 128, 192, 256};
+        // Iterations per measurement.
+        const int kIters = 100000;
+
+        // Measure ns/op for a given (DestBit, SrcBit, BitCount) combination.
+        auto MeasureNs = [&](auto fn, int DestBit, int SrcBit, int BitCount) -> double
+        {
+            // Warm up.
+            for (int i = 0; i < 256; ++i)
+                fn(B.DstFast.data(), DestBit, B.Src.data(), SrcBit, BitCount);
+            auto t0 = clock::now();
+            for (int i = 0; i < kIters; ++i)
+                fn(B.DstFast.data(), DestBit, B.Src.data(), SrcBit, BitCount);
+            auto t1 = clock::now();
+            return std::chrono::duration<double, std::nano>(t1 - t0).count() / kIters;
+        };
+
+        std::printf("\n[sweep] Small-size threshold sweep (%d iters each)\n", kIters);
+        std::printf("  %-9s  %-12s  %-8s  %8s  %8s  %9s  %10s  %10s\n",
+                    "Thresh", "PayloadBits", "Align", "Orig_ns", "Fast_ns", "Gated_ns", "Orig/Gated", "Fast/Gated");
+        std::printf("  %.*s\n", 85, "---------------------"
+                                    "---------------------"
+                                    "---------------------"
+                                    "---------------------"
+                                    "-----");
+
+        for (int thresh : kThresholds)
+        {
+            // Test three payload sizes around the threshold.
+            const int payloads[] = {thresh - 1, thresh, thresh + 1};
+            for (int bits : payloads)
+            {
+                if (bits <= 0)
+                    continue;
+
+                // Aligned: DestBit == SrcBit == 3
+                {
+                    int db = 3, sb = 3;
+                    double origNs = MeasureNs([](uint8 *d, int db2, uint8 *s, int sb2, int bc)
+                                              { FastBitCopy_Internal_Original(d, db2, s, sb2, bc); }, db, sb, bits);
+                    double fastNs = MeasureNs([&](uint8 *d, int db2, uint8 *s, int sb2, int bc)
+                                              { FastBitCopyWithThreshold(d, db2, s, sb2, bc, 0); }, db, sb, bits);
+                    double gatedNs = MeasureNs([&](uint8 *d, int db2, uint8 *s, int sb2, int bc)
+                                               { FastBitCopyWithThreshold(d, db2, s, sb2, bc, thresh); }, db, sb, bits);
+                    std::printf("  %-9d  %-12d  %-8s  %8.1f  %8.1f  %9.1f  %10.2fx  %10.2fx\n",
+                                thresh, bits, "aligned",
+                                origNs, fastNs, gatedNs,
+                                origNs / gatedNs, fastNs / gatedNs);
+                }
+                // Unaligned: DestBit=5, SrcBit=1
+                {
+                    int db = 5, sb = 1;
+                    double origNs = MeasureNs([](uint8 *d, int db2, uint8 *s, int sb2, int bc)
+                                              { FastBitCopy_Internal_Original(d, db2, s, sb2, bc); }, db, sb, bits);
+                    double fastNs = MeasureNs([&](uint8 *d, int db2, uint8 *s, int sb2, int bc)
+                                              { FastBitCopyWithThreshold(d, db2, s, sb2, bc, 0); }, db, sb, bits);
+                    double gatedNs = MeasureNs([&](uint8 *d, int db2, uint8 *s, int sb2, int bc)
+                                               { FastBitCopyWithThreshold(d, db2, s, sb2, bc, thresh); }, db, sb, bits);
+                    std::printf("  %-9d  %-12d  %-8s  %8.1f  %8.1f  %9.1f  %10.2fx  %10.2fx\n",
+                                thresh, bits, "unalign",
+                                origNs, fastNs, gatedNs,
+                                origNs / gatedNs, fastNs / gatedNs);
+                }
+            }
+        }
+        std::printf("\n  Interpretation:\n");
+        std::printf("    Orig/Gated > 1.0 => gated is faster than always-original (good)\n");
+        std::printf("    Fast/Gated > 1.0 => gated is faster than always-fast (expected for small payloads)\n");
+        std::printf("    Ideal threshold: smallest value where Orig/Gated >= 1.0 for both aligned and unaligned.\n\n");
+    }
+
+} // namespace
+
+#endif // FASTBITCOPY_EXPOSE_INTERNALS
 // Forward declaration for the probe defined in FastBitCopy.cpp.
 int FastBitCopy_IsOptimizedBuild();
 
@@ -286,5 +416,8 @@ int main()
     std::mt19937 Rng(0xC0FFEEu);
     int rc = RunCorrectness(Rng);
     RunBench(Rng);
+#if FASTBITCOPY_EXPOSE_INTERNALS
+    RunBenchSweep(Rng);
+#endif
     return rc;
 }

--- a/Source/FastBitCopy/Private/FastBitCopy.cpp
+++ b/Source/FastBitCopy/Private/FastBitCopy.cpp
@@ -370,6 +370,34 @@ void FastBitCopy(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 Bit
 // we're on the optimized path, not the fallback).
 int FastBitCopy_IsOptimizedBuild() { return 1; }
 
+// ---------------------------------------------------------------------------
+// Internal function wrappers for threshold sweep benchmarking.
+//
+// Only compiled when FASTBITCOPY_EXPOSE_INTERNALS is defined (set by the CI
+// CMake build). Never enabled in production UE plugin builds.
+// ---------------------------------------------------------------------------
+#if FASTBITCOPY_EXPOSE_INTERNALS
+
+// Raw aligned fast path (after byte-alignment normalisation).
+void FastBitCopy_Internal_Aligned(uint8 *Dest, uint8 *Src, int BitOffset, int BitCount)
+{
+	BitsCopyFastAligned(Dest, Src, BitOffset, BitCount);
+}
+
+// Raw unaligned fast path (after byte-alignment normalisation).
+void FastBitCopy_Internal_Unaligned(uint8 *Dest, int DestBit, uint8 *Src, int SrcBit, int BitCount)
+{
+	BitsCopyFastUnaligned(Dest, DestBit, Src, SrcBit, BitCount);
+}
+
+// Raw original implementation (FORCEINLINE, same TU).
+void FastBitCopy_Internal_Original(uint8 *Dest, int32 DestBit, uint8 *Src, int32 SrcBit, int32 BitCount)
+{
+	OriginalAppBitsCpyImpl(Dest, DestBit, Src, SrcBit, BitCount);
+}
+
+#endif // FASTBITCOPY_EXPOSE_INTERNALS
+
 #else // !PLATFORM_LITTLE_ENDIAN
 
 // Fallback: just forward to UE's implementation by declaring it and calling through.


### PR DESCRIPTION
## Summary

Adds a RunBenchSweep() function to CI/test_main.cpp that sweeps candidate small-size thresholds and measures performance at the crossover point. This is **P1 of the threshold optimisation plan**: pure data collection, zero production behaviour change.

## What changed

### Source/FastBitCopy/Private/FastBitCopy.cpp
Added a FASTBITCOPY_EXPOSE_INTERNALS guard that emits thin non-static wrappers around the three internal static functions:
- FastBitCopy_Internal_Aligned
- FastBitCopy_Internal_Unaligned
- FastBitCopy_Internal_Original

This flag is **never set in UE plugin builds**. Production FastBitCopy() is unchanged.

### CI/CMakeLists.txt
Added -DFASTBITCOPY_EXPOSE_INTERNALS=1 so the CI standalone build can call the internal wrappers.

### CI/test_main.cpp
Added RunBenchSweep() which sweeps thresholds {8,16,32,48,64,96,128,192,256} bits, measuring Orig_ns / Fast_ns / Gated_ns at payload = thresh-1, thresh, thresh+1 for both aligned (DestBit=SrcBit=3) and unaligned (DestBit=5, SrcBit=1).

## Local Windows/MSVC Release results

`
  Thresh     PayloadBits   Align      Orig_ns   Fast_ns   Gated_ns  Orig/Gated  Fast/Gated
  -------------------------------------------------------------------------------------
  32         33            aligned        8.5       7.5        7.2        1.17x        1.04x
  32         33            unalign        8.1      18.0       15.1        0.54x        1.19x
  48         49            aligned        7.5       7.2        7.2        1.03x        1.00x
  48         49            unalign        7.5      16.5       18.8        0.40x        0.88x
  64         65            aligned        8.4       7.5        7.5        1.12x        1.01x
  64         65            unalign        8.7      18.1       18.1        0.48x        1.00x
  128        129           aligned       13.2       7.5        7.5        1.77x        1.00x
  128        129           unalign       12.2      25.2       25.0        0.49x        1.01x
  256        257           aligned       19.6       7.2        7.4        2.64x        0.98x
  256        257           unalign       21.2      28.5       28.5        0.74x        1.00x
`

## Key findings (to be acted on in P2)

| Path | Current threshold | Data says | P2 action |
|---|---|---|---|
| **Aligned** | 64 bits | Crossover at **32 bits** (1.17× at 33b) | Lower to 32 |
| **Unaligned** | 64 bits | Fast path still slower than Original at every 	hresh+1 tested | Keep at 64, or raise; split into separate threshold |

The unaligned fast path has high fixed overhead (byte-alignment prelude + 64-bit load/store setup). Even at 256-bit threshold, payload=257 unaligned Gated is only 0.74× of Original. This strongly suggests **splitting aligned and unaligned thresholds** in P2.

## CI note
The sweep adds ~30 seconds to the CI run (100k iters × 9 thresholds × 3 payloads × 2 alignments). The correctness tests are unaffected.