### PR TITLE
chore+docs: WSL sweep wrapper and reproducibility section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ FastBitCopy/
 ├── build_testhost.sh             # Linux/macOS build script
 ├── run_testhost.bat             # Windows test script (Editor + Game)
 ├── run_testhost.sh              # Linux/macOS test script (Editor + Game)
+├── run_sweep_wsl.ps1            # Windows: run Linux sweep via WSL (optional)
 ├── .env.example                  # ENGINE_ROOT configuration template
 ├── Source/
 │   ├── FastBitCopy/              # runtime module (installs the hook)
@@ -221,6 +222,51 @@ You can also run them from the command line:
 ```bash
 UnrealEditor-Cmd.exe <YourProject.uproject> -ExecCmds="Automation RunTests FastBitCopy" -unattended -NoPause
 ```
+
+## Reproducing the benchmarks
+
+The speed-up figures in the "Why" table were measured on Windows with a
+source build of UE 5; the CI job in `.github/workflows/ci.yml` exercises
+correctness on every supported compiler and OS but intentionally does
+not gate on absolute throughput. If you want to reproduce or compare
+the numbers on your own hardware, there are three independent entry
+points:
+
+1. **`FastBitCopy.Speed` automation test (UE Editor)** — from inside
+   a real UE project, see the table above. This measures the stock
+   `appBitsCpy`, the installed hook path, and the direct `FastBitCopy`
+   entry point at sizes 1 B – 1 KiB.
+
+2. **Standalone CI harness** — no UE install needed. From a clean
+   checkout:
+
+   ```bash
+   cmake -S CI -B CI/build -DCMAKE_BUILD_TYPE=Release
+   cmake --build CI/build -j
+   ./CI/build/fastbitcopy_ci
+   ```
+
+   The binary runs the same correctness suite as CI and then prints a
+   `[sweep]` table that walks the small-size threshold and byte-vs-bit
+   alignment combinations — this is what was used to pick the internal
+   fast-path cutoffs.
+
+3. **WSL wrapper (`run_sweep_wsl.ps1`)** — convenience script for
+   Windows developers who want a Linux/g++ data point without leaving
+   Windows. It rsyncs the repo into the distro's native ext4
+   (`/mnt/e` is ~5-10× slower and confuses CMake), installs
+   `build-essential cmake rsync`, then builds `CI/` and runs
+   `fastbitcopy_ci`, tee-ing the output to `.agent/sweep-linux.log`:
+
+   ```powershell
+   # Windows PowerShell, from the repo root
+   .\run_sweep_wsl.ps1                       # auto-picks first WSL2 Ubuntu
+   .\run_sweep_wsl.ps1 -SkipDepsInstall      # repeat runs after a source edit
+   .\run_sweep_wsl.ps1 -Distro Ubuntu-24.04  # pin a specific distro
+   ```
+
+   The script never modifies the Windows working tree — it syncs
+   *from* Windows *to* WSL only.
 
 ## API
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -167,6 +167,7 @@ FastBitCopy/
 ├── build_testhost.sh             # Linux/macOS 构建脚本
 ├── run_testhost.bat             # Windows 测试脚本（Editor + Game）
 ├── run_testhost.sh              # Linux/macOS 测试脚本（Editor + Game）
+├── run_sweep_wsl.ps1            # Windows 下通过 WSL 跑 Linux sweep（可选）
 ├── .env.example                  # ENGINE_ROOT 配置模板
 ├── Source/
 │   ├── FastBitCopy/              # 运行时模块（安装 Hook）
@@ -216,6 +217,48 @@ FastBitCopy/
 ```bash
 UnrealEditor-Cmd.exe <你的项目.uproject> -ExecCmds="Automation RunTests FastBitCopy" -unattended -NoPause
 ```
+
+## 复现基准测试
+
+上面 "为什么要做这个" 一节里的加速比数据，是在 Windows + 源码编译的
+UE5 上测得的；CI（`.github/workflows/ci.yml`）会在每种支持的编译器和
+操作系统上跑正确性测试，但**故意不把绝对吞吐量作为 gate**（CPU 因素
+波动过大）。如果你想在自己机器上复现或对比这些数字，有三个互相
+独立的入口：
+
+1. **UE Editor 里的 `FastBitCopy.Speed` 自动化测试** —— 在真实的 UE
+   工程里跑，见上节。会分别测 stock `appBitsCpy` / Hook 路径 /
+   直接调 `FastBitCopy`，尺寸覆盖 1 B – 1 KiB。
+
+2. **独立 CI 测试程序** —— 不需要装 UE，只要有 CMake + C++ 编译器。
+   从仓库根目录：
+
+   ```bash
+   cmake -S CI -B CI/build -DCMAKE_BUILD_TYPE=Release
+   cmake --build CI/build -j
+   ./CI/build/fastbitcopy_ci
+   ```
+
+   这个二进制跑的是与 CI 同一套正确性套件，跑完会打印一张
+   `[sweep]` 表，遍历小尺寸阈值和字节 / bit 对齐组合 —— 这也是
+   我们拿来挑选内部快速路径阈值的数据来源。
+
+3. **WSL 便捷脚本 `run_sweep_wsl.ps1`** —— 给 Windows 开发者用：
+   不用离开 Windows 也能拿到一份 Linux/g++ 的数据点。脚本会把
+   仓库 rsync 到 WSL 的原生 ext4 下（`/mnt/e` 慢 5–10 倍且会让
+   CMake 出怪问题），apt 安装 `build-essential cmake rsync`，
+   然后在 `CI/` 下 Release 构建并运行 `fastbitcopy_ci`，同时把
+   输出 tee 到 `.agent/sweep-linux.log`：
+
+   ```powershell
+   # Windows PowerShell，在仓库根目录下
+   .\run_sweep_wsl.ps1                       # 自动挑第一个 WSL2 的 Ubuntu
+   .\run_sweep_wsl.ps1 -SkipDepsInstall      # 改完源码重跑（已装过依赖）
+   .\run_sweep_wsl.ps1 -Distro Ubuntu-24.04  # 指定具体发行版
+   ```
+
+   脚本**不会**修改 Windows 这边的工作区 —— 它只把 Windows 同步到
+   WSL，不做反向同步。
 
 ## API
 

--- a/run_sweep_wsl.ps1
+++ b/run_sweep_wsl.ps1
@@ -1,0 +1,359 @@
+<#
+.SYNOPSIS
+    Run the CI threshold-sweep benchmark inside WSL (Linux g++) and
+    capture the output for PR attachment.
+
+.DESCRIPTION
+    The P1/P2 threshold tuning work needs cross-platform data: one set
+    from Windows MSVC (run natively) and one from Linux g++. This
+    script automates the Linux side by driving a WSL distro.
+
+    Steps it performs:
+      1. Verify the target WSL distro exists and is WSL2.
+      2. (Optional) apt-install build-essential / cmake / rsync.
+      3. rsync the repo from the Windows workspace to WSL's native
+         ext4 at ~/fastbitcopy-sweep (/mnt/e is 5-10x slower and
+         breaks CMake in subtle ways).
+      4. Configure + build CI/ in Release.
+      5. Run fastbitcopy_ci, tee-ing output to .agent/sweep-linux.log
+         on the Windows side so it can be pasted into the PR.
+
+    Defaults are chosen to match CI (ubuntu-latest == 24.04 right now):
+    if no -Distro is specified the script auto-picks the first WSL2
+    Ubuntu distro available on the host.
+
+.PARAMETER Distro
+    WSL distro name, as shown by `wsl --list --verbose`. When omitted
+    (default) the script picks the first WSL2 distro whose name starts
+    with 'Ubuntu' from `wsl --list --verbose`; this avoids hard-coding
+    a release name that may not exist on every machine.
+
+.PARAMETER Jobs
+    Parallel build jobs. Default: $(nproc) inside the distro.
+
+.PARAMETER SkipDepsInstall
+    Skip the `apt install` step. Use this on repeat runs once the
+    toolchain is known to be present.
+
+.PARAMETER Clean
+    Remove the build directory in WSL before configuring. Use when
+    switching compiler flags, not needed for a plain re-run.
+
+.PARAMETER LogFile
+    Windows-side path for the run log. Default: .agent/sweep-linux.log.
+
+.EXAMPLE
+    # First run: install deps, build, run bench.
+    .\run_sweep_wsl.ps1
+
+.EXAMPLE
+    # Subsequent runs after editing sources on the Windows side.
+    .\run_sweep_wsl.ps1 -SkipDepsInstall
+
+.EXAMPLE
+    # Use a different distro.
+    .\run_sweep_wsl.ps1 -Distro Ubuntu-WSL2 -SkipDepsInstall
+
+.NOTES
+    This script never modifies the Windows working tree; it only
+    syncs *from* Windows *to* WSL. Edits made in WSL are NOT copied
+    back.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Distro = '',
+    [int]$Jobs = 0,
+    [switch]$SkipDepsInstall,
+    [switch]$Clean,
+    [switch]$ProbeOnly,
+    [string]$LogFile = '.agent/sweep-linux.log'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- Locate repo root (directory that contains this script) ---------------
+# $PSScriptRoot is the canonical "directory this script lives in" and works
+# whether the script is run via `.\run_sweep_wsl.ps1`, dot-sourced, or
+# invoked through `pwsh -File`. Unlike $MyInvocation.MyCommand.Path it is
+# not affected by the caller's invocation style.
+$RepoRoot = $PSScriptRoot
+if (-not $RepoRoot) {
+    # Fallback for the very unusual case of being pasted into a REPL.
+    $RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+}
+Push-Location -LiteralPath $RepoRoot
+
+# Resolve the log path relative to repo root so -LogFile can be relative.
+if (-not [System.IO.Path]::IsPathRooted($LogFile)) {
+    $LogFile = Join-Path $RepoRoot $LogFile
+}
+$LogDir = Split-Path -Parent $LogFile
+if ($LogDir -and -not (Test-Path -LiteralPath $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+# --- Sanity-check WSL and the distro -------------------------------------
+function Write-Step($msg) {
+    Write-Host ""
+    Write-Host "==> $msg" -ForegroundColor Cyan
+}
+
+Write-Step "Checking WSL distros"
+# Parse `wsl --list --verbose` to learn which distros exist and which
+# are WSL2. The output is UTF-16LE with no BOM; PowerShell's pipeline
+# decodes it using [Console]::OutputEncoding, which on most systems
+# leaves stray NUL (\0) bytes between every character. We first capture
+# the raw bytes, decode as Unicode, and then scan the resulting text
+# with a regex instead of relying on `-split`-then-`foreach`, which has
+# historically interacted poorly with the embedded NULs on some boxes.
+
+function Get-WslListVerbose {
+    # Capture stdout as a single byte array via cmd.exe redirection, so
+    # we can decode it ourselves regardless of the console code page.
+    $tmp = [IO.Path]::GetTempFileName()
+    try {
+        $null = & cmd.exe /c "wsl.exe --list --verbose > `"$tmp`" 2>nul"
+        $bytes = [IO.File]::ReadAllBytes($tmp)
+    } finally {
+        Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
+    }
+    if ($bytes.Length -ge 2 -and $bytes[0] -eq 0xFF -and $bytes[1] -eq 0xFE) {
+        # UTF-16LE BOM
+        return [Text.Encoding]::Unicode.GetString($bytes, 2, $bytes.Length - 2)
+    }
+    # wsl.exe on recent Windows emits UTF-16LE even without a BOM.
+    # If every other byte is NUL assume UTF-16LE; otherwise treat as ASCII.
+    $even = 0; $odd = 0
+    for ($i = 0; $i -lt [Math]::Min($bytes.Length, 64); $i++) {
+        if ($bytes[$i] -eq 0) { if ($i % 2) { $odd++ } else { $even++ } }
+    }
+    if ($odd -gt 4 -and $even -le 1) {
+        return [Text.Encoding]::Unicode.GetString($bytes)
+    }
+    return [Text.Encoding]::UTF8.GetString($bytes)
+}
+
+$verboseText = Get-WslListVerbose
+
+# Pull distro names out with a single regex pass. The columns are
+# whitespace-separated: [* ] NAME STATE VERSION.
+$allDistros  = New-Object System.Collections.Generic.List[string]
+$wsl2Distros = New-Object System.Collections.Generic.List[string]
+foreach ($m in ([regex]'(?m)^\s*\*?\s*(\S+)\s+\S+\s+(\d+)\s*$').Matches($verboseText)) {
+    $name = $m.Groups[1].Value
+    if ($name -eq 'NAME') { continue }
+    $allDistros.Add($name) | Out-Null
+    if ($m.Groups[2].Value -eq '2') {
+        $wsl2Distros.Add($name) | Out-Null
+    }
+}
+
+if (-not $Distro) {
+    # Auto-pick: prefer an Ubuntu* WSL2 distro, else any WSL2 distro.
+    $Distro = $wsl2Distros | Where-Object { $_ -like 'Ubuntu*' } | Select-Object -First 1
+    if (-not $Distro) {
+        $Distro = $wsl2Distros | Select-Object -First 1
+    }
+    if (-not $Distro) {
+        Pop-Location
+        Write-Error @"
+No WSL2 distro found. ``wsl --list --verbose`` reports:
+$verboseText
+Install one with e.g. 'wsl --install -d Ubuntu-24.04', or pass
+-Distro <name> explicitly.
+"@
+    }
+    Write-Host "Auto-selected distro: $Distro (first Ubuntu* WSL2 found)" -ForegroundColor DarkGray
+} elseif (-not $allDistros.Contains($Distro)) {
+    Pop-Location
+    Write-Error @"
+WSL distro '$Distro' not found. Available distros:
+  $($allDistros -join "`n  ")
+
+Full ``wsl --list --verbose`` output:
+$verboseText
+Install one with e.g. 'wsl --install -d Ubuntu-24.04', or pass
+-Distro <name> matching one of the above. Omit -Distro to auto-pick.
+"@
+}
+# --- Translate Windows repo path to the distro's /mnt path ---------------
+# E:\FastBitCopy  ->  /mnt/e/FastBitCopy
+# UNC paths (\\server\share\...) can't be translated to /mnt/<drive>/...
+# WSL does mount them under /mnt/wsl/... / \\wsl$\ but rsync performance
+# is terrible and the semantics are confusing; bail out with a clear
+# message instead of silently producing a broken path.
+if ($RepoRoot.StartsWith('\\')) {
+    Pop-Location
+    Write-Error @"
+Repo is on a UNC path ($RepoRoot); WSL /mnt translation only handles
+local drive letters (C:, D:, E:, ...). Map the share to a drive letter
+('net use X: \\server\share') and rerun from that drive, or clone the
+repo onto a local disk.
+"@
+}
+if ($RepoRoot.Length -lt 3 -or $RepoRoot[1] -ne ':') {
+    Pop-Location
+    Write-Error "Cannot parse drive letter from RepoRoot='$RepoRoot'."
+}
+$drive = $RepoRoot.Substring(0, 1).ToLowerInvariant()
+$tail  = $RepoRoot.Substring(2).Replace('\', '/')
+$WinRepoInWsl = "/mnt/$drive$tail"
+
+$WslWorkDir = '$HOME/fastbitcopy-sweep'
+
+Write-Step "Windows repo seen from WSL: $WinRepoInWsl"
+Write-Step "WSL working copy:           $WslWorkDir"
+
+# --- Build the bash script we will run inside WSL ------------------------
+# Everything is written as a single heredoc-ish string; we pass it to
+# `wsl -d $Distro bash -c "..."`. We avoid PowerShell string
+# interpolation inside the bash body by using placeholders and a
+# -replace pass.
+
+$bashTemplate = @'
+set -euo pipefail
+
+SRC="__WIN_REPO__"
+DST="__WSL_WORK__"
+JOBS=__JOBS__
+SKIP_DEPS=__SKIP_DEPS__
+CLEAN=__CLEAN__
+
+if [ "$JOBS" = "0" ]; then
+    JOBS="$(nproc)"
+fi
+
+echo ""
+echo "=== fastbitcopy sweep (WSL) ==="
+echo "distro : $(. /etc/os-release 2>/dev/null; echo "${PRETTY_NAME:-unknown}")"
+echo "kernel : $(uname -r)"
+echo "cpu    : $(nproc) cores"
+echo "src    : $SRC"
+echo "dst    : $DST"
+echo "jobs   : $JOBS"
+echo ""
+
+if [ "$SKIP_DEPS" != "1" ]; then
+    echo "--- apt install build tools ---"
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+        build-essential cmake rsync ca-certificates
+fi
+
+command -v rsync  >/dev/null || { echo "rsync missing; rerun without -SkipDepsInstall"; exit 1; }
+command -v cmake  >/dev/null || { echo "cmake missing; rerun without -SkipDepsInstall"; exit 1; }
+command -v g++    >/dev/null || { echo "g++ missing; rerun without -SkipDepsInstall"; exit 1; }
+
+echo ""
+echo "--- versions ---"
+g++ --version | head -n 1
+cmake --version | head -n 1
+echo ""
+
+mkdir -p "$DST"
+
+echo "--- sync sources (rsync, excluding build/agent/VCS scratch) ---"
+rsync -a --delete \
+    --exclude='/.git/' \
+    --exclude='/.agent/' \
+    --exclude='/CI/build/' \
+    --exclude='/CI/build-msvc/' \
+    --exclude='/CI/build-sweep/' \
+    --exclude='/CI/build-verify/' \
+    --exclude='/CI/build-linux/' \
+    --exclude='/TestHost/Binaries/' \
+    --exclude='/TestHost/Intermediate/' \
+    --exclude='/TestHost/DerivedDataCache/' \
+    --exclude='/TestHost/Saved/' \
+    "$SRC/" "$DST/"
+
+cd "$DST"
+
+if [ "$CLEAN" = "1" ]; then
+    echo "--- clean CI/build-linux ---"
+    rm -rf CI/build-linux
+fi
+
+echo ""
+echo "--- cmake configure (Release) ---"
+cmake -S CI -B CI/build-linux -DCMAKE_BUILD_TYPE=Release
+
+echo ""
+echo "--- cmake build ---"
+cmake --build CI/build-linux -j"$JOBS"
+
+echo ""
+echo "--- commit fingerprint ---"
+if command -v git >/dev/null && [ -d .git ]; then
+    echo "git HEAD  : $(git rev-parse --short=12 HEAD) ($(git rev-parse --abbrev-ref HEAD))"
+    echo "worktree  : $(git status --porcelain | wc -l) modified files vs HEAD"
+else
+    echo "(no git metadata in rsynced copy)"
+fi
+
+echo ""
+echo "--- run fastbitcopy_ci ---"
+./CI/build-linux/fastbitcopy_ci
+'@
+
+$bash = $bashTemplate `
+    -replace '__WIN_REPO__', $WinRepoInWsl `
+    -replace '__WSL_WORK__', $WslWorkDir `
+    -replace '__JOBS__',     "$Jobs" `
+    -replace '__SKIP_DEPS__', $(if ($SkipDepsInstall) { '1' } else { '0' }) `
+    -replace '__CLEAN__',     $(if ($Clean)           { '1' } else { '0' })
+
+# bash is whitespace-sensitive in a way that PowerShell isn't: a trailing
+# CR on `set -euo pipefail\r` turns into `set: pipefail<CR>: invalid option
+# name` because bash treats the CR as part of the word. Normalise to LF
+# *before* we hand the script over to wsl.exe, and write it with a
+# UTF-8-no-BOM encoding so `#!` / heredocs aren't disturbed by a BOM.
+$bash = $bash -replace "`r`n", "`n" -replace "`r", "`n"
+
+$tmpBash = Join-Path $env:TEMP ("fbc-sweep-{0}.sh" -f ([IO.Path]::GetRandomFileName()))
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[IO.File]::WriteAllText($tmpBash, $bash, $utf8NoBom)
+
+# Translate the temp file's Windows path to a WSL mount path so we can
+# run `bash <path>` instead of `bash -c "<long string>"` (which is
+# fragile w.r.t. quoting and newline handling on cmd/PowerShell).
+$tmpDrive = $tmpBash.Substring(0, 1).ToLowerInvariant()
+$tmpTail  = $tmpBash.Substring(2).Replace('\', '/')
+$tmpBashInWsl = "/mnt/$tmpDrive$tmpTail"
+
+# --- Execute ------------------------------------------------------------
+Write-Step "Launching WSL build + benchmark (this may take a few minutes)"
+Write-Host "Log file:    $LogFile"   -ForegroundColor DarkGray
+Write-Host "Bash script: $tmpBashInWsl" -ForegroundColor DarkGray
+
+if ($ProbeOnly) {
+    Write-Host ""
+    Write-Host "[-ProbeOnly] Skipping actual WSL invocation. Checks passed:" -ForegroundColor Yellow
+    Write-Host "  distro '$Distro' recognised" -ForegroundColor Yellow
+    Write-Host "  bash script size    : $($bash.Length) chars" -ForegroundColor Yellow
+    Write-Host "  bash script path    : $tmpBash" -ForegroundColor Yellow
+    Remove-Item -LiteralPath $tmpBash -ErrorAction SilentlyContinue
+    Pop-Location
+    exit 0
+}
+
+# Tee output to both console and file. We rely on Tee-Object to avoid
+# writing a half-finished log on Ctrl-C.
+$wslArgs = @('-d', $Distro, '--', 'bash', $tmpBashInWsl)
+$exit = 1
+try {
+    & wsl.exe @wslArgs 2>&1 | Tee-Object -FilePath $LogFile
+    $exit = $LASTEXITCODE
+} finally {
+    Remove-Item -LiteralPath $tmpBash -ErrorAction SilentlyContinue
+    Pop-Location
+}
+Write-Host ""
+if ($exit -eq 0) {
+    Write-Host "==> Sweep finished OK. Log: $LogFile" -ForegroundColor Green
+    Write-Host "    Paste the [sweep] section of the log into your PR description." -ForegroundColor Green
+} else {
+    Write-Host "==> Sweep failed (exit=$exit). See $LogFile for details." -ForegroundColor Red
+}
+exit $exit


### PR DESCRIPTION
Follow-up to #21. Two commits:

**1. `chore(scripts): add run_sweep_wsl.ps1`**
Windows convenience wrapper that runs the CI threshold sweep inside a
WSL2 distro (Linux/g++) and tees the output to `.agent/sweep-linux.log`.
This is what was used to collect the Linux data points while tuning
the small-size thresholds.

Features / hardening vs. the throwaway version used during #21:

- `-Distro` is now optional; the script auto-picks the first WSL2
  `Ubuntu*` distro from `wsl --list --verbose`.
- Uses `$PSScriptRoot` and `Push-Location` / `Pop-Location`, so
  dot-sourcing or running from a different CWD works.
- UNC-path guard: refuses to translate `\\server\share` to a
  `/mnt/<drive>` path and tells the user what to do.
- Prints the synced tree's `git HEAD` short hash and dirty-file count
  in the log, so sweep numbers can later be matched to a commit.
- Writes the bash payload as UTF-8 (no BOM, LF-only) to a temp file
  and runs it via `bash <path>` instead of `bash -c "..."`, which
  avoids the `set: pipefail: invalid option name` CRLF bug seen
  during bring-up.
- `-ProbeOnly` short-circuits before touching WSL for a dry run.
- rsync into WSL's native ext4 (`~/fastbitcopy-sweep`) instead of
  working on `/mnt/e` (5-10x slower and breaks CMake in subtle ways).

**2. `docs(readme): document how to reproduce the threshold benchmarks`**
Keeps the existing 1 MiB "Why" table unchanged (it is Windows/MSVC
data that is still accurate) and adds a new *Reproducing the
benchmarks* section listing three independent entry points:

1. `FastBitCopy.Speed` UE automation test (inside UE).
2. Standalone CI harness - `cmake -S CI -B CI/build && fastbitcopy_ci`
   - no UE install required; prints the `[sweep]` table used to pick
   the internal thresholds.
3. The new `run_sweep_wsl.ps1` wrapper for Windows devs who want a
   Linux/g++ data point without leaving Windows.

Also registers `run_sweep_wsl.ps1` in the README's repository-layout
tree. README and README_CN kept in sync.

**Tested locally**

- `.\run_sweep_wsl.ps1 -ProbeOnly` on a Windows 11 box with 7 distros
  installed correctly auto-picks a WSL2 Ubuntu.
- `.\run_sweep_wsl.ps1 -ProbeOnly -Distro DoesNotExist` emits the full
  diagnostic and bails before any WSL invocation.
- Prior full sweep run (pre-wrapper-polish) produced the Linux data
  already pasted into #21.
