### PR TITLE
perf: pipeline CopyBitsSrcAligned shift-word loop (1 load/1 store per iter)

### DIFF
--- a/Source/FastBitCopy/Private/FastBitCopy.cpp
+++ b/Source/FastBitCopy/Private/FastBitCopy.cpp
@@ -127,14 +127,51 @@ static void CopyBitsSrcAligned(WordType *Dest, int DestBit, WordType *Src, int B
 		{
 			const uint32 UDestBit = uint32(DestBit);
 			const uint32 UDestCopyBits = uint32(DestCopyBits);
+			// Pipelined shift-word loop.
+			//
+			// The natural formulation does 3 loads (Src[i], Dest[i], Dest[i+1])
+			// and 2 stores per iteration. But Dest[i] in iteration i already
+			// contains "Word_{i-1} >> UDestCopyBits" in its low DestBit bits,
+			// written by the previous iteration's store to Dest[i]. That write
+			// was itself fed by the read of the *original* Dest[i-1]'s low
+			// DestBit bits (via `D0 & ~Mask`). So across the whole loop only
+			// the low DestBit bits of Dest[0] and the high DestCopyBits bits
+			// of Dest[LoopCount] ever matter as "original" Dest content; every
+			// other "Dest" read is recovering something we just wrote.
+			//
+			// We exploit that by carrying a single `Overflow` register across
+			// iterations:
+			//   - Overflow's low DestBit bits always hold the bits that belong
+			//     in the low DestBit bits of the next Dest[i] to be written.
+			//   - Bootstrap: read Dest[0]'s low DestBit bits once before the
+			//     loop.
+			//   - After writing Dest[i], update Overflow = Word >> UDestCopyBits,
+			//     which is exactly "Word's high DestCopyBits bits, sitting in
+			//     the low DestCopyBits bit positions" -- i.e. what belongs in
+			//     the low part of Dest[i+1]. (The low DestBit bits of Dest[i+1]'s
+			//     *original* value don't need to be preserved: they get
+			//     overwritten by Word_{i+1} << UDestBit in the next store,
+			//     exactly as in the unpipelined version.)
+			//   - Tail-up: after LoopCount iterations, Overflow still holds the
+			//     high bits of Word_{LoopCount-1}, which must go into the low
+			//     DestCopyBits bits of Dest[LoopCount]. Merge with the
+			//     (untouched) high DestBit bits of the original Dest[LoopCount].
+			//
+			// Net I/O per iteration: 1 Src load + 1 Dest store. Outside the
+			// loop: 2 loads + 1 store total. Roughly half the memory traffic
+			// of the original shape on the hot path.
+			WordType Overflow = WordType(LoadWordUnaligned(&Dest[0]) & ~Mask);
 			for (int i = 0; i < LoopCount; ++i)
 			{
 				const WordType Word = LoadWordUnaligned(&Src[i]);
-				const WordType D0 = LoadWordUnaligned(&Dest[i]);
-				const WordType D1 = LoadWordUnaligned(&Dest[i + 1]);
-				StoreWordUnaligned(&Dest[i], WordType((D0 & ~Mask) | WordType(Word << UDestBit)));
-				StoreWordUnaligned(&Dest[i + 1], WordType((D1 & Mask) | WordType(Word >> UDestCopyBits)));
+				StoreWordUnaligned(&Dest[i], WordType(Overflow | WordType(Word << UDestBit)));
+				Overflow = WordType(Word >> UDestCopyBits);
 			}
+			// Merge the carried Overflow into Dest[LoopCount]'s low bits,
+			// preserving its original high DestBit bits. This is the exact
+			// final state the old 2-store-per-iter loop left Dest[LoopCount] in.
+			const WordType DLast = LoadWordUnaligned(&Dest[LoopCount]);
+			StoreWordUnaligned(&Dest[LoopCount], WordType((DLast & Mask) | Overflow));
 		}
 		Src += LoopCount;
 		Dest += LoopCount;


### PR DESCRIPTION
## What

Pipeline the hot inner loop of `CopyBitsSrcAligned`'s `DestBit != 0`
branch so each iteration does **1 Src load + 1 Dest store** instead of
3 loads + 2 stores. This is the unaligned fast path that dominates
`FastBitCopy` cost for payloads of several hundred bits and up.

## Why

The original shape was:

```cpp
for (i = 0; i < LoopCount; ++i)
{
    Word = Load(&Src[i]);
    D0   = Load(&Dest[i]);           // low DestBit bits needed
    D1   = Load(&Dest[i + 1]);       // high DestBit bits needed
    Store(&Dest[i],     (D0 & ~Mask) | (Word << UDestBit));
    Store(&Dest[i + 1], (D1 &  Mask) | (Word >> UDestCopyBits));
}
```

Reading `Dest[i+1]` in iteration `i` and `Dest[i]` in iteration `i+1` is
redundant: across the whole loop, only the low `DestBit` bits of
`Dest[0]` and the high `DestBit` bits of `Dest[LoopCount]` ever need to
come from the **original** Dest memory. Every other "Dest" read is just
recovering bits the previous iteration already stored.

## How

Carry a single `Overflow` register across iterations:

```cpp
WordType Overflow = Load(&Dest[0]) & ~Mask;       // bootstrap
for (i = 0; i < LoopCount; ++i)
{
    Word = Load(&Src[i]);
    Store(&Dest[i], Overflow | (Word << UDestBit));
    Overflow = Word >> UDestCopyBits;
}
// tail-up: merge carried overflow into Dest[LoopCount] low bits,
// preserving its untouched high DestBit bits.
DLast = Load(&Dest[LoopCount]);
Store(&Dest[LoopCount], (DLast & Mask) | Overflow);
```

Properties:

- **Final memory state is bit-identical** to the old loop. The tail path
  (both the `uint8` specialisation and the `uint64` byte-tail branch)
  sees exactly the same Dest contents as before, so it needs no changes.
- **Access range is unchanged**. The old loop already touched
  `Dest[LoopCount]` on its last iteration via `Dest[i + 1]`, so we don't
  extend the caller's required buffer bounds.
- **Only the `DestBit != 0` branch** is modified. The `DestBit == 0`
  memcpy shortcut and the entire aligned path (`BitsCopyFastAligned`)
  are untouched.

## Measurements

Same bench harness that PR #23 hardened against DCE. 8192-bit unaligned
payload, 20 000 iterations, `SrcBit=1 DestBit=5`:

| Compiler | Before | After | Speedup |
|---|---|---|---|
| MSVC 19.44 /O2  | 139.9 ns/op | **86.8 ns/op** | **1.61x** |
| g++  13.3  -O2  | 141.5 ns/op | **94.3 ns/op** | **1.50x** |

Sweep data (g++ -O2, WSL2) shows the win is consistent across the whole
medium / large payload range:

| Payload bits | Fast before (ns) | Fast after (ns) | Speedup |
|---|---|---|---|
| 255  | 24.1 | **16.4** | 1.47x |
| 383  | 26.2 | **17.2** | 1.52x |
| 511  | 27.9 | **18.1** | 1.54x |
| 767  | 32.7 | **20.1** | 1.63x |
| 1023 | 36.1 | **22.3** | 1.62x |
| 2047 | 50.5 | **31.9** | 1.58x |

Roughly a **1.5-1.65x** uniform speedup on the unaligned hot path. The
original hypothesis was 20-30% from halving loads; the actual impact is
larger because modern x64/ARM64 cores handle unaligned loads cheaply and
the real bottleneck was the **store port**. Dropping from 2 stores per
iteration to 1 unlocked most of this.

## Follow-up note (not part of this PR)

The unaligned path's crossover with `OriginalAppBitsCpy` has now moved
**from ~320 bits down to ~128 bits**. The `FASTBITCOPY_SMALL_BITS_UNALIGNED = 256`
threshold landed in PR #24 (before this speedup) is now conservative; a
subsequent PR can lower it to ~128 to capture the new 129-256 bit wins.

## Correctness

- 11 deterministic edge cases pass on both MSVC and g++.
- 20 000 random correctness trials (uniform over `DestBit`, `SrcBit`,
  `BitCount` ranges) pass on both.
- Smoke prints (stack + heap sentinel variants) match expected byte
  patterns.
- Reasoning for bit-identity is written up in the in-file comment so
  future readers don't have to re-derive it.

## Files touched

- `Source/FastBitCopy/Private/FastBitCopy.cpp` -- 41 insertions,
  4 deletions, single function touched
  (`CopyBitsSrcAligned<WordType>::DestBit != 0` branch). No header,
  no public API, no build-system changes.
